### PR TITLE
make it possible to list queued command in current channel only

### DIFF
--- a/command/queue/queue.go
+++ b/command/queue/queue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"encoding/json"
 	"github.com/innogames/slack-bot/bot/storage"
+	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
 	"github.com/nlopes/slack"
 	"github.com/sirupsen/logrus"
@@ -31,7 +32,7 @@ func AddRunningCommand(event slack.MessageEvent, fallbackCommand string) chan bo
 	if fallbackCommand != "" {
 		event.Text = fallbackCommand
 
-		queueKey = getKey(event)
+		queueKey = util.GetFullEventKey(event)
 		storage.Write(storageKey, queueKey, event)
 	}
 

--- a/command/queue/queue_test.go
+++ b/command/queue/queue_test.go
@@ -90,6 +90,23 @@ func TestQueue(t *testing.T) {
 		actual = command.Run(event)
 		assert.Equal(t, true, actual)
 
+		// list queue for current channel
+		event.Text = "list queue in channel"
+		slackClient.On("Reply", event, mock.MatchedBy(func(input string) bool {
+			return strings.HasPrefix(input, "1 queued commands")
+		}))
+		actual = command.Run(event)
+		assert.Equal(t, true, actual)
+
+		// list queue for other channel
+		event.Text = "list queue in channel"
+		event.Channel = "C1212121"
+		slackClient.On("Reply", event, mock.MatchedBy(func(input string) bool {
+			return strings.HasPrefix(input, "0 queued commands")
+		}))
+		actual = command.Run(event)
+		assert.Equal(t, true, actual)
+
 		done <- true
 		time.Sleep(time.Millisecond * 300)
 


### PR DESCRIPTION
Added "list queue in channel" to only list queued commands in current channel
Useful e.g. to list pending pull requests.