### PR TITLE
WIP: replace deprecated functions

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -112,7 +112,7 @@ func (b *bot) loadChannels() error {
 
 		chunkedChannels, cursor, err = b.slackClient.GetConversations(options)
 		if err != nil {
-			return errors.Wrap(err, "error while fetching public channels")
+			return err
 		}
 		for _, channel := range chunkedChannels {
 			client.Channels[channel.ID] = channel.Name

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -245,7 +245,7 @@ func (b bot) handleMessage(event slack.MessageEvent) {
 
 	_, existing := b.allowedUsers[event.User]
 	if !existing && event.SubType != TypeInternal && b.config.Slack.TestEndpointUrl == "" {
-		logger.Errorf("user %s is not allowed to execute message: %s", event.User, event.Text)
+		logger.Errorf("user %s is not allowed to execute message (missing in 'allowed_users' section): %s", event.User, event.Text)
 		b.slackClient.Reply(event, "Sorry, you are not whitelisted yet. Please ask the slack-bot admin to get access.")
 		return
 	}

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/bot/matcher"
 	"github.com/innogames/slack-bot/client"
-	"github.com/slack-go/slack"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bot/interaction/handler.go
+++ b/bot/interaction/handler.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/innogames/slack-bot/bot/storage"
 	"github.com/innogames/slack-bot/client"
+	"github.com/pkg/errors"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
-	"github.com/pkg/errors"
 )
 
 func (s *Server) healthCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/bot/interaction/server.go
+++ b/bot/interaction/server.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/client"
-	"github.com/slack-go/slack"
 	log "github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 // NewServer is used to receive slack interactions

--- a/bot/logger.go
+++ b/bot/logger.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/client"
-	"github.com/slack-go/slack"
 	"github.com/rifflock/lfshook"
 	log "github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 // GetLogger provides logger instance for the given config

--- a/bot/tester/tester.go
+++ b/bot/tester/tester.go
@@ -11,10 +11,10 @@ import (
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/command"
-	"github.com/slack-go/slack"
-	"github.com/slack-go/slack/slacktest"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slacktest"
 )
 
 // TestChannel is just a test channel name which is used for testing

--- a/client/jenkins/start_build.go
+++ b/client/jenkins/start_build.go
@@ -10,9 +10,9 @@ import (
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/command/queue"
-	"github.com/slack-go/slack"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 var mu sync.Mutex

--- a/client/jenkins/start_build_test.go
+++ b/client/jenkins/start_build_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/mocks"
-	"github.com/slack-go/slack"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/slack.go
+++ b/client/slack.go
@@ -9,8 +9,8 @@ import (
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/bot/storage"
 	"github.com/innogames/slack-bot/bot/util"
-	"github.com/slack-go/slack"
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 // InternalMessages is internal queue of internal messages
@@ -138,13 +138,17 @@ func (s Slack) SendToUser(user string, text string) string {
 	// check if a real username was passed -> we need the user-id here
 	user, _ = GetUser(user)
 
-	_, _, channel, err := s.Client.OpenIMChannel(user)
+	options := &slack.OpenConversationParameters{
+		Users: []string{user},
+	}
+
+	channel, _, _, err := s.Client.OpenConversation(options)
 	if err != nil {
 		s.logger.WithError(err).Errorf("Cannot open channel")
 	}
 
 	event := slack.MessageEvent{}
-	event.Channel = channel
+	event.Channel = channel.ID
 
 	return s.SendMessage(event, text)
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -14,8 +14,8 @@ import (
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/bot/storage"
 	"github.com/innogames/slack-bot/bot/tester"
-	"github.com/slack-go/slack"
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 // starts a interactive shell to communicate with a fake slack server and execute real commands

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,12 @@ jenkins:
           default: master
           type: branch
 
+# list of trusted slack users: allowes the user-id and the name
+allowed_users:
+  - your.name
+  - U122323
+
+# wip: allows receiving events directly from Slack server instead via RTM
 #server:
 #  listen: 127.0.0.1:4390
 #  verification_secret: d12345sd943434sdfdsfsif9sif9

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,7 +28,7 @@ jenkins:
           default: master
           type: branch
 
-# list of trusted slack users: allowes the user-id and the name
+# list of trusted slack users: allows the user-id and the name
 allowed_users:
   - your.name
   - U122323

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/PuloV/ics-golang v0.0.0-20190808201353-a3394d3bcade
 	github.com/ae6rt/retry v2.0.0+incompatible // indirect
-	github.com/alicebob/miniredis/v2 v2.13.0
+	github.com/alicebob/miniredis/v2 v2.13.1
 	github.com/bndr/gojenkins v1.0.1
 	github.com/channelmeter/iso8601duration v0.0.0-20150204201828-8da3af7a2a61 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
@@ -14,11 +14,12 @@ require (
 	github.com/go-redis/redis/v7 v7.4.0
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/gomodule/redigo v1.8.2 // indirect
+	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/gookit/color v1.2.6
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
-	github.com/imdario/mergo v0.3.9
+	github.com/imdario/mergo v0.3.10
 	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
@@ -31,7 +32,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slack-go/slack v0.6.5
-	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6
 	github.com/trivago/tgo v1.0.7 // indirect
@@ -40,7 +41,7 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,12 @@ This slack bot improves the workflow of development teams. Especially with focus
 [Docker](https://hub.docker.com/r/brainexe/slack-bot)
 
 # Installation
+**Create Classic Slack App:**
+- Create a [Classic Slack App](https://api.slack.com/apps?new_classic_app=1)
+- Goto "Bot" section and create a "Legacy Bot user" 
+- Goto "OAuth & Permissions" and install the app in your workspace
+- A "Bot User OAuth Access Token" is visible (starts with "xoxb-"). You need this one in the config.yaml in slack->token.
+
 **Quick steps:** (just use the bot via Docker)
 - install Docker incl. docker-compose
 - clone this repo or at least fetch the docker-compose.yaml
@@ -142,7 +148,7 @@ It's possible to create buttons which are performing any bot action when pressin
  
 **Config without a public reachable IP/Domain**
 1) start local [ngrok.io](https://ngrok.io) server (using local port 4390 by default)
-2) In [App settings](https://api.slack.com/apps) open the "Interactive Components" for your app.
+2) In [App settings](https://api.slack.com/apps) open the "Interactivity & Shortcuts" for your app and make sure it's enabled.
 3) Add the request URL. E.g. https://foobar.eu.ngrok.io/commands (Note: `/commands` is the slack-bot handle)
 4) In "Basic Information" of the Slack app, use the "Signing Secret" as verification_secret below:
 5) Add this to the config and start the bot:
@@ -377,7 +383,7 @@ crons:
 ```
 
 ### Calendar
-Trigger commands by calendar entries of an ical/icl calenar.
+Trigger commands by calendar entries of an ical/icl calendar.
 
 **Example:**
 ```

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ This slack bot improves the workflow of development teams. Especially with focus
 - install Docker incl. docker-compose
 - clone this repo or at least fetch the docker-compose.yaml
 - create a config.yaml (at least a slack token is required) or take a look in config-example.yaml
+- allow your user id or name in the "allowed_users:" section of the config.yaml
 - `docker-compose up`
 
 **Advanced** (when planning working on the bot core)


### PR DESCRIPTION
see #26 

https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

List of affected functions:
- [x] channels.list
- [x] im.open
- [ ] rtm


rtm:
https://github.com/slackapi/node-slack-sdk/issues/953

**Docs**
https://api.slack.com/authentication/quickstart
https://api.slack.com/authentication/migration