### PR TITLE
refactoring: Part 1 to replace slack.MessageEvent in command context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+## Describe the problem
+
+A clear and concise description of what the bug is.
+
+## Debug information
+Bot Version (commit, version, tag etc): 
+Affected command: 
+Command example:
+
+## Config
+Please post the full yaml config (Please remove all URLs, passwords, token etc!)
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Additional context
+
+Add any other context about the problem here.
+e.g., detailed error logs etc

--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,5 @@
+# see https://github.com/marketplace/actions/release-drafter
+
+template: |
+  ## What's Changed
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -34,7 +34,7 @@ func TestBot(t *testing.T) {
 		event := slack.MessageEvent{}
 		event.Text = ""
 		event.Channel = "C123"
-		bot.handleMessage(event)
+		bot.handleMessage(event, true)
 	})
 
 	t.Run("handle unauthenticated message", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestBot(t *testing.T) {
 		event.Text = "test"
 		event.User = "U888"
 		event.Channel = "C123"
-		bot.handleMessage(event)
+		bot.handleMessage(event, true)
 	})
 
 	t.Run("handle valid message", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestBot(t *testing.T) {
 		event.Text = "test"
 		event.User = "U123"
 		event.Channel = "C123"
-		bot.handleMessage(event)
+		bot.handleMessage(event, true)
 		fmt.Println(bot.slackClient.RTM.IncomingEvents)
 	})
 }
@@ -89,7 +89,6 @@ func TestIsBotMessage(t *testing.T) {
 
 	t.Run("Pass internal events", func(t *testing.T) {
 		event := &slack.MessageEvent{}
-		event.SubType = TypeInternal
 		event.User = "U1234"
 		event.Text = "<@BOT> random test"
 

--- a/bot/fallback.go
+++ b/bot/fallback.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"math"
 	"strings"
 
@@ -24,7 +25,7 @@ func (b *Bot) sendFallbackMessage(event slack.MessageEvent) {
 	b.slackClient.SendMessage(event, "Command `"+event.Text+"` not found...do you mean *"+bestMatching.Command+"* command?")
 
 	event.Text = fmt.Sprintf("help %s", bestMatching.Command)
-	client.InternalMessages <- event
+	client.InternalMessages <- msg.FromSlackEvent(event)
 }
 
 func getBestMatchingHelp(b *Bot, eventText string) Help {

--- a/bot/logger.go
+++ b/bot/logger.go
@@ -38,9 +38,6 @@ func (b Bot) getUserBasedLogger(event slack.MessageEvent) *log.Entry {
 	} else {
 		_, channel = client.GetChannel(event.Channel)
 	}
-	if event.SubType == TypeInternal {
-		channel += " (internal)"
-	}
 
 	return b.logger.
 		WithField("channel", channel).

--- a/bot/msg/message.go
+++ b/bot/msg/message.go
@@ -1,0 +1,16 @@
+package msg
+
+const typeInternal = "internal"
+
+type Message struct {
+	Text            string
+	Channel         string
+	Thread          string
+	User            string
+	Timestamp       string
+	InternalMessage bool
+}
+
+func (msg *Message) IsInternalMessage() bool {
+	return msg.InternalMessage
+}

--- a/bot/msg/message_test.go
+++ b/bot/msg/message_test.go
@@ -1,0 +1,52 @@
+package msg
+
+import (
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMessage(t *testing.T) {
+	t.Run("Slack event to Message", func(t *testing.T) {
+		event := slack.MessageEvent{
+			Msg: slack.Msg{
+				Text:      "foo",
+				Timestamp: "12344",
+				User:      "U123",
+			},
+		}
+		actual := FromSlackEvent(event)
+
+		expected := Message{
+			Text:            "foo",
+			User:            "U123",
+			Timestamp:       "12344",
+			InternalMessage: false,
+		}
+
+		assert.Equal(t, expected, actual)
+		assert.Equal(t, false, actual.IsInternalMessage())
+	})
+
+	t.Run("Message to Slack event", func(t *testing.T) {
+		message := Message{
+			Text:            "foo",
+			User:            "U123",
+			Timestamp:       "12344",
+			InternalMessage: true,
+		}
+		assert.Equal(t, true, message.IsInternalMessage())
+
+		expected := slack.MessageEvent{
+			Msg: slack.Msg{
+				Text:      "foo",
+				Timestamp: "12344",
+				User:      "U123",
+				SubType:   typeInternal,
+			},
+		}
+		actual := message.ToSlackEvent()
+
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/bot/msg/slack.go
+++ b/bot/msg/slack.go
@@ -1,0 +1,32 @@
+package msg
+
+import "github.com/slack-go/slack"
+
+func (msg *Message) ToSlackEvent() slack.MessageEvent {
+	subtype := ""
+	if msg.InternalMessage {
+		subtype = typeInternal
+	}
+
+	return slack.MessageEvent{
+		Msg: slack.Msg{
+			Text:            msg.Text,
+			Channel:         msg.Channel,
+			ThreadTimestamp: msg.Thread,
+			User:            msg.User,
+			Timestamp:       msg.Timestamp,
+			SubType:         subtype,
+		},
+	}
+}
+
+func FromSlackEvent(event slack.MessageEvent) Message {
+	return Message{
+		Text:            event.Text,
+		Channel:         event.Channel,
+		Thread:          event.ThreadTimestamp,
+		User:            event.User,
+		Timestamp:       event.Timestamp,
+		InternalMessage: event.SubType == typeInternal,
+	}
+}

--- a/bot/server/handler.go
+++ b/bot/server/handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -36,7 +37,7 @@ func (s *Server) eventHandler(w http.ResponseWriter, r *http.Request) {
 
 		switch ev := innerEvent.Data.(type) {
 		case slackevents.MessageEvent:
-			client.InternalMessages <- slack.MessageEvent{
+			client.InternalMessages <- msg.Message{
 				// todo fill
 			}
 		default:
@@ -101,7 +102,7 @@ func (s *Server) interactionHandler(w http.ResponseWriter, r *http.Request) {
 	storage.Delete("interactions", action.Value)
 	event.User = payload.User.ID
 
-	client.InternalMessages <- event
+	client.InternalMessages <- msg.FromSlackEvent(event)
 
 	newMessage := getChangedMessage(payload.Message, action.Value)
 	w.WriteHeader(http.StatusOK)

--- a/bot/tester/tester.go
+++ b/bot/tester/tester.go
@@ -22,7 +22,7 @@ const TestChannel = "#dev"
 const botID = "W12345"
 
 // StartBot will start this bot against the fake slack instance
-func StartBot(cfg config.Config, logger *logrus.Logger) bot.Handler {
+func StartBot(cfg config.Config, logger *logrus.Logger) *bot.Bot {
 	slackClient := client.GetSlackClient(cfg.Slack, logger)
 
 	commands := command.GetCommands(

--- a/client/jenkins/jenkins.go
+++ b/client/jenkins/jenkins.go
@@ -2,6 +2,7 @@ package jenkins
 
 import (
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"time"
 
 	"github.com/bndr/gojenkins"
@@ -69,6 +70,6 @@ func processHooks(commands []string, event slack.MessageEvent, params map[string
 		text, _ := util.EvalTemplate(temp, params)
 
 		event.Text = text
-		client.InternalMessages <- event
+		client.InternalMessages <- msg.FromSlackEvent(event)
 	}
 }

--- a/client/slack.go
+++ b/client/slack.go
@@ -4,6 +4,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"strings"
 
 	"github.com/innogames/slack-bot/bot/config"
@@ -14,7 +15,7 @@ import (
 )
 
 // InternalMessages is internal queue of internal messages
-var InternalMessages = make(chan slack.MessageEvent, 50)
+var InternalMessages = make(chan msg.Message, 50)
 
 // BotUserID is filled with the slack user id of the bot
 var BotUserID = ""

--- a/command/cron/command.go
+++ b/command/cron/command.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/config"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
 	"github.com/sirupsen/logrus"
@@ -59,7 +60,7 @@ func (c *command) getCallback(cron config.Cron) func() {
 			newMessage.User = "cron"
 			newMessage.Channel, _ = client.GetChannel(cron.Channel)
 			newMessage.Text = text
-			client.InternalMessages <- newMessage
+			client.InternalMessages <- msg.FromSlackEvent(newMessage)
 		}
 	}
 }

--- a/command/custom/handle.go
+++ b/command/custom/handle.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/slack-go/slack"
 	"strings"
@@ -19,7 +20,7 @@ func (c command) Handle(event slack.MessageEvent) bool {
 	for _, command := range strings.Split(commands, ";") {
 		newMessage := event
 		newMessage.Text = command
-		client.InternalMessages <- newMessage
+		client.InternalMessages <- msg.FromSlackEvent(newMessage)
 	}
 
 	return true

--- a/command/custom/integration_test.go
+++ b/command/custom/integration_test.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"github.com/innogames/slack-bot/bot"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/mocks"
 	"github.com/slack-go/slack"
@@ -87,7 +88,7 @@ func TestCustomCommands(t *testing.T) {
 		event.User = "user1"
 
 		handledEvent := <-client.InternalMessages
-		assert.Equal(t, handledEvent, event)
+		assert.Equal(t, handledEvent, msg.FromSlackEvent(event))
 	})
 
 	t.Run("Delete command with invalid syntax", func(t *testing.T) {

--- a/command/delay.go
+++ b/command/delay.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/matcher"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/command/queue"
@@ -61,7 +62,7 @@ func (c *delayCommand) Delay(match matcher.Result, event slack.MessageEvent) {
 
 		newMessage := event
 		newMessage.Text = command
-		client.InternalMessages <- newMessage
+		client.InternalMessages <- msg.FromSlackEvent(newMessage)
 	}()
 }
 

--- a/command/delay_test.go
+++ b/command/delay_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"github.com/innogames/slack-bot/bot"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/mocks"
 	"github.com/slack-go/slack"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestDelay(t *testing.T) {
-	client.InternalMessages = make(chan slack.MessageEvent, 2)
+	client.InternalMessages = make(chan msg.Message, 2)
 	slackClient := mocks.SlackClient{}
 
 	command := bot.Commands{}
@@ -59,7 +60,7 @@ func TestDelay(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, handledEvent, expectedEvent)
+		assert.Equal(t, handledEvent, msg.FromSlackEvent(expectedEvent))
 	})
 
 	t.Run("Test quiet option", func(t *testing.T) {
@@ -83,7 +84,7 @@ func TestDelay(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, handledEvent, expectedEvent)
+		assert.Equal(t, handledEvent, msg.FromSlackEvent(expectedEvent))
 	})
 
 	t.Run("Test stop", func(t *testing.T) {

--- a/command/jira/search_ticket.go
+++ b/command/jira/search_ticket.go
@@ -52,9 +52,6 @@ func (c *jiraCommand) Run(match matcher.Result, event slack.MessageEvent) {
 
 	if ticketNumber != "" {
 		issue, response, err := c.jira.Issue.Get(ticketNumber, nil)
-		if response != nil {
-			defer response.Body.Close()
-		}
 		if response == nil || response.StatusCode > 400 {
 			c.slackClient.Reply(event, err.Error())
 			return
@@ -251,10 +248,7 @@ func (c *jiraCommand) GetHelp() []bot.Help {
 func (c *jiraCommand) GetTemplateFunction() template.FuncMap {
 	return template.FuncMap{
 		"jiraTicket": func(ticketId string) *jira.Issue {
-			issue, resp, _ := c.jira.Issue.Get(ticketId, nil)
-			if resp != nil {
-				resp.Body.Close()
-			}
+			issue, _, _ := c.jira.Issue.Get(ticketId, nil)
 
 			return issue
 		},

--- a/command/macro.go
+++ b/command/macro.go
@@ -5,6 +5,7 @@ import (
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/config"
 	"github.com/innogames/slack-bot/bot/matcher"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
 	"github.com/sirupsen/logrus"
@@ -77,7 +78,7 @@ func (c *macroCommand) Execute(event slack.MessageEvent) bool {
 			for _, part := range strings.Split(text, "\n") {
 				newMessage := event
 				newMessage.Text = part
-				client.InternalMessages <- newMessage
+				client.InternalMessages <- msg.FromSlackEvent(newMessage)
 			}
 		}
 

--- a/command/macro_test.go
+++ b/command/macro_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/config"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/mocks"
 	"github.com/sirupsen/logrus"
@@ -15,7 +16,7 @@ func TestInvalidMacro(t *testing.T) {
 	slackClient := &mocks.SlackClient{}
 	logger := logrus.New()
 
-	client.InternalMessages = make(chan slack.MessageEvent, 2)
+	client.InternalMessages = make(chan msg.Message, 2)
 	cfg := []config.Macro{
 		{
 			Name: "Test",
@@ -42,7 +43,7 @@ func TestMacro(t *testing.T) {
 	logger := logrus.New()
 
 	slackClient := &mocks.SlackClient{}
-	client.InternalMessages = make(chan slack.MessageEvent, 2)
+	client.InternalMessages = make(chan msg.Message, 2)
 	cfg := []config.Macro{
 		{
 			Name: "Test",
@@ -75,16 +76,12 @@ func TestMacro(t *testing.T) {
 		assert.NotEmpty(t, client.InternalMessages)
 
 		handledEvent := <-client.InternalMessages
-		assert.Equal(t, handledEvent, slack.MessageEvent{
-			Msg: slack.Msg{
-				Text: "macro 1",
-			},
+		assert.Equal(t, handledEvent, msg.Message{
+			Text: "macro 1",
 		})
 		handledEvent = <-client.InternalMessages
-		assert.Equal(t, handledEvent, slack.MessageEvent{
-			Msg: slack.Msg{
-				Text: "macro test",
-			},
+		assert.Equal(t, handledEvent, msg.Message{
+			Text: "macro test",
 		})
 		assert.Empty(t, client.InternalMessages)
 	})

--- a/command/queue/command.go
+++ b/command/queue/command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/matcher"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
@@ -65,7 +66,7 @@ func (c *command) Run(match matcher.Result, event slack.MessageEvent) {
 			// trigger new command
 			newMessage := event
 			newMessage.Text = command
-			client.InternalMessages <- newMessage
+			client.InternalMessages <- msg.FromSlackEvent(newMessage)
 
 			c.logger.Infof("[Queue] Blocking command is over, eval newMessage: %s", newMessage.Text)
 			return

--- a/command/queue/queue.go
+++ b/command/queue/queue.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/bot/storage"
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
@@ -86,7 +87,7 @@ func executeFallbackCommand(logger *logrus.Logger) {
 		}
 
 		logger.Infof("[Queue] Booted! I'll trigger this command now: `%s`", event.Text)
-		client.InternalMessages <- event
+		client.InternalMessages <- msg.FromSlackEvent(event)
 	}
 	storage.DeleteCollection(storageKey)
 }

--- a/command/queue/queue_test.go
+++ b/command/queue/queue_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"github.com/innogames/slack-bot/bot/msg"
 	"strconv"
 	"testing"
 	"time"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestQueue(t *testing.T) {
-	client.InternalMessages = make(chan slack.MessageEvent, 2)
+	client.InternalMessages = make(chan msg.Message, 2)
 	slackClient := &mocks.SlackClient{}
 
 	event := slack.MessageEvent{}
@@ -113,12 +114,10 @@ func TestQueue(t *testing.T) {
 		assert.NotEmpty(t, client.InternalMessages)
 
 		handledEvent := <-client.InternalMessages
-		assert.Equal(t, handledEvent, slack.MessageEvent{
-			Msg: slack.Msg{
-				Timestamp: event.Timestamp,
-				User:      "testUser1",
-				Text:      "reply test",
-			},
+		assert.Equal(t, handledEvent, msg.Message{
+			Timestamp: event.Timestamp,
+			User:      "testUser1",
+			Text:      "reply test",
 		})
 	})
 }

--- a/command/retry.go
+++ b/command/retry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/innogames/slack-bot/bot"
 	"github.com/innogames/slack-bot/bot/matcher"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/bot/storage"
 	"github.com/innogames/slack-bot/bot/util"
 	"github.com/innogames/slack-bot/client"
@@ -31,7 +32,7 @@ func (c *retryCommand) GetMatcher() matcher.Matcher {
 }
 
 func (c *retryCommand) Execute(event slack.MessageEvent) bool {
-	if event.SubType == bot.TypeInternal {
+	if event.SubType == "internal" {
 		return false
 	}
 
@@ -49,7 +50,7 @@ func (c *retryCommand) Execute(event slack.MessageEvent) bool {
 
 		newMessage := event
 		newMessage.Text = lastCommand
-		client.InternalMessages <- newMessage
+		client.InternalMessages <- msg.FromSlackEvent(newMessage)
 	} else {
 		c.slackClient.Reply(event, "Sorry, no history found.")
 	}

--- a/command/retry_test.go
+++ b/command/retry_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"github.com/innogames/slack-bot/bot"
+	"github.com/innogames/slack-bot/bot/msg"
 	"github.com/innogames/slack-bot/client"
 	"github.com/innogames/slack-bot/mocks"
 	"github.com/slack-go/slack"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestRetry(t *testing.T) {
-	client.InternalMessages = make(chan slack.MessageEvent, 2)
+	client.InternalMessages = make(chan msg.Message, 2)
 	slackClient := mocks.SlackClient{}
 
 	retry := bot.Commands{}
@@ -20,7 +21,7 @@ func TestRetry(t *testing.T) {
 		event := slack.MessageEvent{}
 		event.User = "testUser1"
 		event.Text = "i'm a submessage"
-		event.SubType = bot.TypeInternal
+		event.SubType = "internal"
 
 		actual := retry.Run(event)
 		assert.Equal(t, false, actual)
@@ -55,7 +56,7 @@ func TestRetry(t *testing.T) {
 		assert.NotEmpty(t, client.InternalMessages)
 
 		handledEvent := <-client.InternalMessages
-		assert.Equal(t, handledEvent, event)
+		assert.Equal(t, handledEvent, msg.FromSlackEvent(event))
 	})
 
 	t.Run("With with other user", func(t *testing.T) {

--- a/command/send_message.go
+++ b/command/send_message.go
@@ -24,7 +24,7 @@ func (c *sendMessageCommand) GetMatcher() matcher.Matcher {
 func (c *sendMessageCommand) SendMessage(match matcher.Result, event slack.MessageEvent) {
 	text := match.GetString("text")
 	if event.User != "" {
-		text = fmt.Sprintf("Message from <@%s>: %s", event.User, text)
+		text = fmt.Sprintf("Text from <@%s>: %s", event.User, text)
 	}
 
 	if match.GetString("type") == "#" {

--- a/command/send_message_test.go
+++ b/command/send_message_test.go
@@ -27,7 +27,7 @@ func TestSendMessage(t *testing.T) {
 		event.Text = "send message <@1234|testuser> message"
 		event.User = "testUser1"
 
-		slackClient.On("SendToUser", "1234", "Message from <@testUser1>: message").Return("")
+		slackClient.On("SendToUser", "1234", "Text from <@testUser1>: message").Return("")
 		slackClient.On("Reply", event, "I'll send `message` to <@1234|testuser>")
 		actual := command.Run(event)
 		assert.Equal(t, true, actual)
@@ -38,7 +38,7 @@ func TestSendMessage(t *testing.T) {
 		event.Text = "send message <#JDGS|general> message"
 		event.User = "testUser1"
 
-		slackClient.On("Reply", slack.MessageEvent{Msg: slack.Msg{Channel: "JDGS"}}, "Message from <@testUser1>: message").Return("")
+		slackClient.On("Reply", slack.MessageEvent{Msg: slack.Msg{Channel: "JDGS"}}, "Text from <@testUser1>: message").Return("")
 		slackClient.On("Reply", event, "I'll send `message` to <#JDGS|general>")
 		actual := command.Run(event)
 		assert.Equal(t, true, actual)


### PR DESCRIPTION
use custom struct which holds the message data.
avoid passing slack.MessageEvent through all places