### PR TITLE
internal: make test more stable 

### DIFF
--- a/command/defined_commands_test.go
+++ b/command/defined_commands_test.go
@@ -58,6 +58,9 @@ func TestMacro(t *testing.T) {
 	slackClient := &mocks.SlackClient{}
 	base := bot.BaseCommand{SlackClient: slackClient}
 
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
+
 	client.InternalMessages = make(chan msg.Message, 2)
 	cfg := []config.Command{
 		{

--- a/command/delay_test.go
+++ b/command/delay_test.go
@@ -23,6 +23,9 @@ func TestDelay(t *testing.T) {
 	command := bot.Commands{}
 	command.AddCommand(NewDelayCommand(base))
 
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
+
 	t.Run("Invalid command", func(t *testing.T) {
 		message := msg.Message{}
 		message.Text = "I have a delay"

--- a/command/queue/queue_test.go
+++ b/command/queue/queue_test.go
@@ -25,6 +25,9 @@ func TestQueue(t *testing.T) {
 	command.AddCommand(NewQueueCommand(base))
 	command.AddCommand(NewListCommand(base))
 
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
+
 	t.Run("Invalid command", func(t *testing.T) {
 		message := msg.Message{}
 		actual := command.Run(message)

--- a/command/retry.go
+++ b/command/retry.go
@@ -32,7 +32,7 @@ func (c *retryCommand) GetMatcher() matcher.Matcher {
 	return matcher.NewGroupMatcher(
 		matcher.NewTextMatcher(`retry`, c.retry),
 		matcher.NewTextMatcher(`repeat`, c.retry),
-		matcher.NewRegexpMatcher(`<?https://(.*)slack.com/archives/(?P<channel>\w+)/p(?P<timestamp>\d{16})>?`, c.slackMessage),
+		matcher.NewRegexpMatcher(`<?https://(.*?)\.slack\.com/archives/(?P<channel>\w+)/p(?P<timestamp>\d{16})>?`, c.slackMessage),
 		matcher.WildcardMatcher(c.storeLastCommand),
 	)
 }

--- a/command/retry_test.go
+++ b/command/retry_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestRetry(t *testing.T) {
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
+
 	client.InternalMessages = make(chan msg.Message, 2)
 	slackClient := &mocks.SlackClient{}
 	cfg := &config.Config{}

--- a/mocks/testing.go
+++ b/mocks/testing.go
@@ -11,9 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+// testLock is only used in integration test to avoid running some tests in parallel as we use one shared Message list
+var testLock sync.Mutex
 
 // AssertSlackMessage is a test helper to check for a given slack message
 func AssertSlackMessage(slackClient *SlackClient, ref msg.Ref, text string) {
@@ -98,6 +102,12 @@ func AssertContainsSlackBlocks(t *testing.T, slackClient *SlackClient, message m
 
 		return strings.Contains(string(givenJSON), string(expectedJSONBlock))
 	}), mock.Anything).Once().Return("")
+}
+
+func LockInternalMessages() *sync.Mutex {
+	testLock.Lock()
+
+	return &testLock
 }
 
 // WaitTillHavingInternalMessage blocks until there is a internal message queued


### PR DESCRIPTION
(avoid issues with shared access to internal message list)