### PR TITLE
fix: change viper key delimiter to support "-" in config map keys

### DIFF
--- a/bot/config/config_test.go
+++ b/bot/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +52,11 @@ func TestLoadFile(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg.Slack)
 	assert.Equal(t, "info", cfg.Logger.Level)
+
+	t.Run("loadFile", func(t *testing.T) {
+		err := loadFile(viper.New(), "sdsd.yaml")
+		assert.Equal(t, "open sdsd.yaml: no such file or directory", err.Error())
+	})
 }
 
 func TestEnvironment(t *testing.T) {

--- a/bot/config/config_test.go
+++ b/bot/config/config_test.go
@@ -55,7 +55,7 @@ func TestLoadFile(t *testing.T) {
 
 	t.Run("loadFile", func(t *testing.T) {
 		err := loadFile(viper.New(), "sdsd.yaml")
-		assert.Equal(t, "open sdsd.yaml: no such file or directory", err.Error())
+		assert.Contains(t, err.Error(), "open sdsd.yaml: ")
 	})
 }
 

--- a/bot/config/loader.go
+++ b/bot/config/loader.go
@@ -12,22 +12,21 @@ import (
 
 // Load all yaml config from a directory or a single .yaml file
 func Load(configFile string) (Config, error) {
-	v := viper.NewWithOptions(viper.KeyDelimiter("-"), viper.KeyPreserveCase())
+	// don't use '.' or '_' etc as delimiter, as it will block having this chars as map keys
+	var keyDelimiter = "§"
+	v := viper.NewWithOptions(viper.KeyDelimiter(keyDelimiter), viper.KeyPreserveCase())
 
 	v.SetConfigType("yaml")
 	v.AllowEmptyEnv(true)
 	v.SetEnvPrefix("BOT")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", keyDelimiter, "_"))
 	v.AutomaticEnv()
 
 	cfg := DefaultConfig
 
 	// workaround to take all keys from struct available
 	defaultYaml, _ := yaml.Marshal(DefaultConfig)
-	err := v.ReadConfig(bytes.NewBuffer(defaultYaml))
-	if err != nil {
-		return cfg, err
-	}
+	_ = v.ReadConfig(bytes.NewBuffer(defaultYaml))
 
 	fileInfo, err := os.Stat(configFile)
 	if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,7 +2,7 @@
 slack:
   token: # use xoxb-1234567-secret
   socket_token: # needed for Socket mode, starts with "xapp-"
-  debug: false # some more slack information
+  debug: false # some more slack debug information
 
 # list of trusted slack users: allows the user-id and the name
 allowed_users:
@@ -24,53 +24,34 @@ commands:
       - reply I deployed {{.branch}}
       - add link "Open Admintool" https://project.example.com/admintool/
 
-  - name: List open Jira bugs
-    trigger: "open (?P<project>(backend|mobile|frontend)) bugs"
-    description: "Lists open Jira bugs from a given component"
-    category: QA
-    commands:
-      - "add reaction :bug:"
-      - jql issuetype = Bug AND component = "{{.project}}" AND resolution = Unresolved ORDER BY priority DESC, created DESC
-    examples:
-      - open backend bugs
-      - open mobile bugs
-      - open frontend bugs
-
-  - name: demo
-    trigger: "demo (?P<ticketId>\\w+-\\d+)"
-    commands:
-      - |
-        {{ $ticket := jiraTicket .ticketId }}
-        {{ if $ticket }}
-          reply <!here> demo for <{{ jiraTicketUrl $ticket.Key }}|{{ $ticket.Key }}: {{ $ticket.Fields.Summary }}>
-        {{ else }}
-          reply Ticket {{ .ticketId }} not found :white_frowning_face:
-        {{ end }}
-    description: Informs the current channel about a demo of a Jira ticket. It directly posts a link to the ticket
-    examples:
-      - demo XYZ-1232
+#  - name: List open Jira bugs
+#    trigger: "open (?P<project>(backend|mobile|frontend)) bugs"
+#    description: "Lists open Jira bugs from a given component"
+#    category: QA
+#    commands:
+#      - "add reaction :bug:"
+#      - jql issuetype = Bug AND component = "{{.project}}" AND resolution = Unresolved ORDER BY priority DESC, created DESC
+#    examples:
+#      - open backend bugs
+#      - open mobile bugs
+#      - open frontend bugs
 
 # optional Jenkins integration
-jenkins:
-  host: #https://jenkins.example.com
-  username: username
-  password: secret
-  jobs:
-    BackendTests:
-      parameters:
-        - name: BRANCH
-          default: master
-          type: branch
-    BuildMobileClient:
-      parameters:
-        - name: BRANCH
-          default: master
-          type: branch
-    BuildFrontendClient:
-      parameters:
-        - name: BRANCH
-          default: master
-          type: branch
+#jenkins:
+#  host: https://jenkins.example.com
+#  username: username
+#  password: secret
+#  jobs:
+#    BackendTests:
+#      parameters:
+#        - name: BRANCH
+#          default: master
+#          type: branch
+#    BuildFrontendClient:
+#      parameters:
+#        - name: BRANCH
+#          default: master
+#          type: branch
 
 # optional Jira integration
 jira:
@@ -84,12 +65,12 @@ github:
   access_token: # optional when using github features
 
 # optional Gitlab integration to watch merge request state
-gitlab:
+#gitlab:
 #  host: https://gitlab.example.de
-#  accesstoken: # optional when using gitlab features
+#  accesstoken: # needed for the API
 
 
-# used for the "weather" command to fetch current weather information from openweathermap.org
+# used for the "weather" command to fetch current weather information from https://openweathermap.org/api
 #open_weathermap:
 #  apikey: iamtheapifromopenweathermap
 #  location: Hamburg


### PR DESCRIPTION
broken config: 
```yaml
pullrequest:
  custom_approve_reaction:
    dev1: "approved_backend"
    nerd-dev: "approved_backend"
```

**Error:** 
```
FATA[0000] 1 error(s) decoding:
* 'pullrequest.custom_approve_reaction[nerd]' expected type 'util.Reaction', got unconvertible type 'map[string]interface {}', value: 'map[dev:approved_backend]' 
exit status 1
```