### PR TITLE
fixed build for linux/386 due to "overflows int"

### DIFF
--- a/bot/util/duration.go
+++ b/bot/util/duration.go
@@ -31,7 +31,7 @@ func FormatDuration(duration time.Duration) string {
 	// extract days out of duration
 	fullDays := int(duration.Hours() / 24)
 	if fullDays > 0 {
-		duration -= time.Duration(int(time.Hour) * 24 * fullDays)
+		duration -= time.Hour * 24 * time.Duration(fullDays)
 		output += fmt.Sprintf("%dd", fullDays)
 	}
 	output += duration.String()

--- a/bot/util/duration_test.go
+++ b/bot/util/duration_test.go
@@ -44,6 +44,7 @@ var formatterTestCases = []struct {
 	{time.Hour*10 + time.Second*12, "10h0m12s"},
 	{time.Hour*10 + time.Second*12 + 11*time.Millisecond, "10h0m12s"},
 	{time.Hour*2 + time.Minute*5 + 25*time.Second, "2h5m25s"},
+	{time.Hour * 24, "1d0s"},
 	{time.Hour*26 + time.Minute*5 + 25*time.Second, "1d2h5m25s"},
 	{time.Hour*1000 + 25*time.Second, "41d16h0m25s"},
 }


### PR DESCRIPTION
# github.com/innogames/slack-bot/bot/util
bot/util/duration.go:34:32: constant 3600000000000 overflows int
bot/util/duration.go:34:44: constant 86400000000000 overflows int