### PR TITLE
Jenkins: fixed link to console.

### DIFF
--- a/client/jenkins/start_build.go
+++ b/client/jenkins/start_build.go
@@ -204,7 +204,7 @@ func getFinishBuildText(build *gojenkins.Build, user string, jobName string) str
 	duration := time.Duration(build.GetDuration()) * time.Millisecond
 
 	text := fmt.Sprintf(
-		"<@%s> *%s:* %s #%d took %s: <%s|Build> <%sconsole/|Console>",
+		"<@%s> *%s:* %s #%d took %s: <%s|Build> <%sconsole|Console>",
 		user,
 		build.GetResult(),
 		jobName,

--- a/client/jenkins/start_build_test.go
+++ b/client/jenkins/start_build_test.go
@@ -72,7 +72,7 @@ func TestStartBuild(t *testing.T) {
 		build.Raw.URL = "https://jenkins.example.com/job/test/12/"
 
 		actual := getFinishBuildText(build, "user123", "testJob")
-		expected := "<@user123> *FAILURE:* testJob #1233 took 3m0s: <https://jenkins.example.com/job/test/12/|Build> <https://jenkins.example.com/job/test/12/console/|Console>\nRetry the build by using `retry build testJob #1233`"
+		expected := "<@user123> *FAILURE:* testJob #1233 took 3m0s: <https://jenkins.example.com/job/test/12/|Build> <https://jenkins.example.com/job/test/12/console|Console>\nRetry the build by using `retry build testJob #1233`"
 
 		assert.Equal(t, expected, actual)
 	})


### PR DESCRIPTION
**Issue**
https://jenkins.example.de/job/YourJobName/26637/console/ -> redirects now to the status page

Just remove the trailing /