### PR TITLE
fix order of executed "commands"

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -216,8 +216,10 @@ func (b *Bot) ProcessMessage(message msg.Message, fromUserContext bool) {
 	}
 
 	// prevent messages from one user processed in parallel (usual + internal ones)
-	lock := b.getUserLock(message.User)
-	defer lock.Unlock()
+	if message.Done != nil {
+		lock := b.getUserLock(message.User)
+		defer lock.Unlock()
+	}
 
 	stats.IncreaseOne(stats.TotalCommands)
 

--- a/cmd/cli/integration_test.go
+++ b/cmd/cli/integration_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/innogames/slack-bot/v2/mocks"
+
 	"github.com/gookit/color"
 	"github.com/innogames/slack-bot/v2/bot/config"
 	"github.com/innogames/slack-bot/v2/bot/tester"
@@ -24,6 +26,9 @@ func TestAll(t *testing.T) {
 
 	color.Enable = false
 	cfg := config.Config{}
+
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
 
 	ctx := util.NewServerContext()
 

--- a/command/defined_commands.go
+++ b/command/defined_commands.go
@@ -81,9 +81,10 @@ func (c *definedCommand) execute(ref msg.Ref, text string) bool {
 				continue
 			}
 
-			// each line is interpreted as command
+			// each line is interpreted as separate command and is execute the a blocking mode
 			for _, part := range strings.Split(text, "\n") {
-				client.HandleMessage(ref.WithText(part))
+				message := client.HandleMessageWithDoneHandler(ref.WithText(part))
+				message.Wait()
 			}
 		}
 

--- a/command/delay_test.go
+++ b/command/delay_test.go
@@ -89,7 +89,6 @@ func TestDelay(t *testing.T) {
 		}
 
 		assert.Equal(t, handledEvent, msg.FromSlackEvent(expectedEvent))
-		assert.Equal(t, 0, queue.CountCurrentJobs())
 	})
 
 	t.Run("Test stop", func(t *testing.T) {

--- a/command/delay_test.go
+++ b/command/delay_test.go
@@ -61,9 +61,8 @@ func TestDelay(t *testing.T) {
 		assert.Empty(t, client.InternalMessages)
 		assert.Equal(t, 1, queue.CountCurrentJobs())
 
-		mocks.WaitTillHavingInternalMessage()
+		handledEvent := mocks.WaitTillHavingInternalMessage()
 
-		handledEvent := <-client.InternalMessages
 		expectedEvent := msg.Message{
 			Text: "my command",
 		}
@@ -82,9 +81,7 @@ func TestDelay(t *testing.T) {
 		assert.True(t, actual)
 		assert.Empty(t, client.InternalMessages)
 
-		mocks.WaitTillHavingInternalMessage()
-
-		handledEvent := <-client.InternalMessages
+		handledEvent := mocks.WaitTillHavingInternalMessage()
 		expectedEvent := &slack.MessageEvent{
 			Msg: slack.Msg{
 				Text: "my command",

--- a/command/queue/queue_test.go
+++ b/command/queue/queue_test.go
@@ -135,9 +135,7 @@ func TestQueue(t *testing.T) {
 		})
 
 		runningCommand.Done()
-		mocks.WaitTillHavingInternalMessage()
-
-		handledEvent := <-client.InternalMessages
+		handledEvent := mocks.WaitTillHavingInternalMessage()
 
 		expectedMessage := msg.Message{}
 		expectedMessage.Timestamp = message.Timestamp


### PR DESCRIPTION
 - execute commands blocking to keep the order in sync
 - also "then" is supported now.

 Example:
```yaml
  - name: build and deploy
    #...
    commands:
      - 'trigger job BuildClient {{ .branch }}'
      - 'then trigger job Deploy  {{.branch}} {{.environment}}'
      - 'then reply I deployed {{.branch}} to {{.environment}} :smile:'
    examples:
      - deploy and build master to beta
```