### PR TITLE
Suggest new user and group restriction 

### DIFF
--- a/bot/tester/fake_server.go
+++ b/bot/tester/fake_server.go
@@ -26,6 +26,13 @@ func StartFakeSlack(cfg *config.Config, output io.Writer) *slacktest.Server {
 			bytes, _ := json.Marshal(users)
 			_, _ = w.Write(bytes)
 		})
+		c.Handle("/usergroups.list", func(w http.ResponseWriter, _ *http.Request) {
+			groups := userGroupsResponse{
+				Groups: []slack.UserGroup{},
+			}
+			bytes, _ := json.Marshal(groups)
+			_, _ = w.Write(bytes)
+		})
 		c.Handle("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
 			messageHandler(w, r, output)
 		})

--- a/bot/tester/tester.go
+++ b/bot/tester/tester.go
@@ -69,6 +69,10 @@ type usersResponse struct {
 	Members []slack.User
 }
 
+type userGroupsResponse struct {
+	Groups []slack.UserGroup
+}
+
 // kinda dirty grown function to format a /chat.postMessage /chat.postEphemeral message on the command like...somehow
 func messageHandler(w http.ResponseWriter, r *http.Request, output io.Writer) {
 	payload, _ := ioutil.ReadAll(r.Body)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,7 @@ slack:
   token: # use xoxb-1234567-secret
   socket_token: # needed for Socket mode, starts with "xapp-"
   debug: false # some more slack debug information
+  allowed_groups: [] # allowed slack user group id or name. you need paid slack plan
 
 # list of trusted slack users: allows the user-id and the name
 allowed_users:


### PR DESCRIPTION
- Enhance slack user group and user name restriction
  - Possible to add user group with providing both user group id and name 
  - If no user name provided, default is all user can use general user command(not admin) 
- Remove bugs in aws cloud front command