### PR TITLE
enh: improve blocking commands for custom commands.

### DIFF
--- a/cmd/cli/integration_test.go
+++ b/cmd/cli/integration_test.go
@@ -11,12 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/innogames/slack-bot/v2/mocks"
-
 	"github.com/gookit/color"
 	"github.com/innogames/slack-bot/v2/bot/config"
 	"github.com/innogames/slack-bot/v2/bot/tester"
 	"github.com/innogames/slack-bot/v2/bot/util"
+	"github.com/innogames/slack-bot/v2/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,6 +51,8 @@ func TestAll(t *testing.T) {
 	// custom commands
 	testCommand("add command 'wtf' 'reply bar'", "Added command: reply bar. Just use wtf in future.", input, expectedOutput)
 	testCommand("wtf", "executing command: reply bar\nbar", input, expectedOutput)
+	testCommand("add command 'timer-test' 'delay 100ms quiet reply foo; delay 1ms quiet reply bar'", "Added command: delay 100ms quiet reply foo; delay 1ms quiet reply bar. Just use timer-test in future.", input, expectedOutput)
+	testCommand("timer-test", "executing command: delay 100ms quiet reply foo; delay 1ms quiet reply bar\nbar\nfoo", input, expectedOutput)
 
 	time.Sleep(time.Second * 1)
 

--- a/command/custom/handle.go
+++ b/command/custom/handle.go
@@ -19,7 +19,8 @@ func (c command) handle(ref msg.Ref, text string) bool {
 
 	c.SendMessage(ref, fmt.Sprintf("executing command: `%s`", commands))
 	for _, command := range strings.Split(commands, ";") {
-		client.HandleMessage(ref.WithText(command))
+		message := client.HandleMessageWithDoneHandler(ref.WithText(command))
+		message.Wait()
 	}
 
 	return true

--- a/command/custom/integration_test.go
+++ b/command/custom/integration_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/msg"
-	"github.com/innogames/slack-bot/v2/client"
 	"github.com/innogames/slack-bot/v2/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,6 +12,9 @@ import (
 func TestCustomCommands(t *testing.T) {
 	slackClient := &mocks.SlackClient{}
 	base := bot.BaseCommand{SlackClient: slackClient}
+
+	lock := mocks.LockInternalMessages()
+	defer lock.Unlock()
 
 	commands := bot.Commands{}
 	commands.AddCommand(GetCommand(base))
@@ -30,7 +32,9 @@ func TestCustomCommands(t *testing.T) {
 		message := msg.Message{}
 		message.Text = "list commands"
 		message.User = "user1"
-		slackClient.On("SendMessage", message, "No commands define yet. Use `add command 'your alias' 'command to execute'`").Return("")
+
+		mocks.AssertSlackMessage(slackClient, message, "No commands define yet. Use `add command 'your alias' 'command to execute'`")
+
 		actual := commands.Run(message)
 		assert.True(t, actual)
 	})
@@ -48,7 +52,8 @@ func TestCustomCommands(t *testing.T) {
 		message.User = "user1"
 		message.Text = "add command 'alias 1' 'reply 1'"
 
-		slackClient.On("SendMessage", message, "Added command: `reply 1`. Just use `alias 1` in future.").Return("")
+		mocks.AssertSlackMessage(slackClient, message, "Added command: `reply 1`. Just use `alias 1` in future.")
+
 		actual := commands.Run(message)
 
 		assert.True(t, actual)
@@ -59,7 +64,7 @@ func TestCustomCommands(t *testing.T) {
 		message.User = "user1"
 		message.Text = "list commands"
 
-		slackClient.On("SendMessage", message, "You defined 1 commands:\n - alias 1: `reply 1`").Return("")
+		mocks.AssertSlackMessage(slackClient, message, "You defined 1 commands:\n - alias 1: `reply 1`")
 		actual := commands.Run(message)
 
 		assert.True(t, actual)
@@ -78,19 +83,20 @@ func TestCustomCommands(t *testing.T) {
 		message.User = "user1"
 		message.Text = "alias 1"
 
-		slackClient.On("SendMessage", message, "executing command: `reply 1`").Return("")
+		mocks.AssertSlackMessage(slackClient, message, "executing command: `reply 1`")
 
-		assert.Empty(t, client.InternalMessages)
+		getMessages := mocks.WaitForQueuedMessages(t, 1)
+
 		actual := commands.Run(message)
 		assert.True(t, actual)
-		assert.Len(t, client.InternalMessages, 1)
 
-		message = msg.Message{}
-		message.Text = "reply 1"
-		message.User = "user1"
+		messages := getMessages()
 
-		handledEvent := <-client.InternalMessages
-		assert.Equal(t, handledEvent, message)
+		expected := msg.Message{}
+		expected.Text = "reply 1"
+		expected.User = "user1"
+
+		assert.Equal(t, expected, messages[0])
 	})
 
 	t.Run("Delete command with invalid syntax", func(t *testing.T) {
@@ -108,7 +114,7 @@ func TestCustomCommands(t *testing.T) {
 		message.Text = "delete command 'alias 1'"
 		message.User = "user1"
 
-		slackClient.On("SendMessage", message, "Okay, I deleted command: `alias 1`").Return("")
+		mocks.AssertSlackMessage(slackClient, message, "Okay, I deleted command: `alias 1`")
 
 		actual := commands.Run(message)
 

--- a/command/defined_commands_test.go
+++ b/command/defined_commands_test.go
@@ -1,9 +1,7 @@
 package command
 
 import (
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
@@ -104,30 +102,15 @@ func TestDefinedCommands(t *testing.T) {
 		message := msg.Message{}
 		message.Text = "start test"
 
-		// the command is pushing the messages in the client.InternalMessages and waits until the command is done
-		wg := &sync.WaitGroup{}
-		wg.Add(2) // we expect 2 commands to be called in the background
-		var actualMessages []msg.Message
-		go func() {
-			for message := range client.InternalMessages {
-				// mark as handled -> the command can add the next command
-				// just some time to test if the concurrency works
-				time.Sleep(time.Millisecond * 5)
-
-				message.Done.Done()
-				actualMessages = append(actualMessages, message)
-				wg.Done()
-			}
-		}()
+		getMessages := mocks.WaitForQueuedMessages(t, 2)
 
 		// run the command -> it's blocking until all sub-commands are handled
 		assert.Empty(t, client.InternalMessages)
 		actual := command.Run(message)
 		assert.True(t, actual)
 
-		wg.Wait()
+		actualMessages := getMessages()
 
-		assert.Len(t, actualMessages, 2)
 		assert.Equal(t, "macro 1", actualMessages[0].Text)
 		assert.Equal(t, "macro test", actualMessages[1].Text)
 	})


### PR DESCRIPTION
- support something like "add command 'deploy' 'trigger job BuildClients ; then trigger job Deploy'