### PR TITLE
add option to notify user about the pr status

### DIFF
--- a/bot/config/default.go
+++ b/bot/config/default.go
@@ -22,11 +22,18 @@ var DefaultConfig = Config{
 		},
 	},
 	PullRequest: PullRequest{
+		Notifications: Notifications{
+			BuildStatusInProgress:      false,
+			BuildStatusSuccess:         false,
+			BuildStatusFailed:          false,
+			PullRequestStatusMergeable: false,
+		},
 		Reactions: PullRequestReactions{
 			InReview:     "eyes",
 			Approved:     "white_check_mark",
 			Merged:       "twisted_rightwards_arrows",
 			Closed:       "x",
+			BuildSuccess: "white_check_mark",
 			BuildFailed:  "fire",
 			BuildRunning: "arrows_counterclockwise",
 			Error:        "x",

--- a/bot/config/pull_request.go
+++ b/bot/config/pull_request.go
@@ -7,8 +7,20 @@ type PullRequest struct {
 	// overwrite reactions, default ones, see default.go
 	Reactions PullRequestReactions `mapstructure:"reactions"`
 
+	// enable private notifications for the build status
+	Notifications Notifications `mapstructure:"notifications"`
+
 	// able to set a custom "approved" reactions to see directly who or which component/department approved a pullrequest
 	CustomApproveReaction map[string]util.Reaction `mapstructure:"custom_approve_reaction"`
+}
+
+// Notifications can be defined in the config.yaml to enable notifications for pull request builds.
+// the defaults are defined in default.go
+type Notifications struct {
+	BuildStatusInProgress      bool `mapstructure:"build_status_in_progress"`
+	BuildStatusSuccess         bool `mapstructure:"build_status_success"`
+	BuildStatusFailed          bool `mapstructure:"build_status_failed"`
+	PullRequestStatusMergeable bool `mapstructure:"pr_status_mergeable"`
 }
 
 // PullRequestReactions can be defined in the config.yaml to have custom reactions for pull requests.
@@ -18,7 +30,8 @@ type PullRequestReactions struct {
 	Approved     util.Reaction `mapstructure:"approved"`
 	Merged       util.Reaction `mapstructure:"merged"`
 	Closed       util.Reaction `mapstructure:"closed"`
-	BuildFailed  util.Reaction `mapstructure:"build_failed"`
+	BuildSuccess util.Reaction `mapstructure:"build_success"`
 	BuildRunning util.Reaction `mapstructure:"build_running"`
+	BuildFailed  util.Reaction `mapstructure:"build_failed"`
 	Error        util.Reaction `mapstructure:"error"`
 }

--- a/client/slack.go
+++ b/client/slack.go
@@ -108,7 +108,7 @@ type SlackClient interface {
 	SendBlockMessage(ref msg.Ref, blocks []slack.Block, options ...slack.MsgOption) string
 
 	// SendToUser sends a simple text message to a user, using "@username or @U12334"
-	SendToUser(user string, format string, params ...any)
+	SendToUser(user string, text string)
 	RemoveReaction(reaction util.Reaction, ref msg.Ref)
 	AddReaction(reaction util.Reaction, ref msg.Ref)
 	GetReactions(item slack.ItemRef, params slack.GetReactionsParameters) ([]slack.ItemReaction, error)
@@ -210,7 +210,7 @@ func (s *Slack) ReplyError(ref msg.Ref, err error) {
 }
 
 // SendToUser sends a message to any user via IM channel
-func (s *Slack) SendToUser(user string, format string, params ...any) {
+func (s *Slack) SendToUser(user string, text string) {
 	// check if a real username was passed -> we need the user-id here
 	userID, _ := GetUserIDAndName(user)
 	if userID == "" {
@@ -231,7 +231,7 @@ func (s *Slack) SendToUser(user string, format string, params ...any) {
 	message := msg.Message{}
 	message.Channel = channel.ID
 
-	s.SendMessage(message, fmt.Sprintf(format, params...))
+	s.SendMessage(message, text)
 }
 
 // CanHandleInteractions checks if we have a slack connections which can inform us about events/interactions, like pressed buttons?

--- a/client/slack.go
+++ b/client/slack.go
@@ -108,7 +108,7 @@ type SlackClient interface {
 	SendBlockMessage(ref msg.Ref, blocks []slack.Block, options ...slack.MsgOption) string
 
 	// SendToUser sends a simple text message to a user, using "@username or @U12334"
-	SendToUser(user string, text string)
+	SendToUser(user string, format string, params ...any)
 	RemoveReaction(reaction util.Reaction, ref msg.Ref)
 	AddReaction(reaction util.Reaction, ref msg.Ref)
 	GetReactions(item slack.ItemRef, params slack.GetReactionsParameters) ([]slack.ItemReaction, error)
@@ -210,7 +210,7 @@ func (s *Slack) ReplyError(ref msg.Ref, err error) {
 }
 
 // SendToUser sends a message to any user via IM channel
-func (s *Slack) SendToUser(user string, text string) {
+func (s *Slack) SendToUser(user string, format string, params ...any) {
 	// check if a real username was passed -> we need the user-id here
 	userID, _ := GetUserIDAndName(user)
 	if userID == "" {
@@ -231,7 +231,7 @@ func (s *Slack) SendToUser(user string, text string) {
 	message := msg.Message{}
 	message.Channel = channel.ID
 
-	s.SendMessage(message, text)
+	s.SendMessage(message, fmt.Sprintf(format, params...))
 }
 
 // CanHandleInteractions checks if we have a slack connections which can inform us about events/interactions, like pressed buttons?

--- a/command/pullrequest/bitbucket.go
+++ b/command/pullrequest/bitbucket.go
@@ -130,15 +130,12 @@ func (c *bitbucketFetcher) getBuildStatus(lastCommit string) buildStatus {
 			if status == buildStatusUnknown {
 				status = buildStatusSuccess
 			}
-			break
 		case "INPROGRESS":
 			status = buildStatusRunning
-			break
 		case "FAILED":
 			if status != buildStatusRunning {
 				status = buildStatusFailed
 			}
-			break
 		}
 	}
 

--- a/command/pullrequest/bitbucket.go
+++ b/command/pullrequest/bitbucket.go
@@ -69,10 +69,22 @@ func (c *bitbucketFetcher) getPullRequest(match matcher.Result) (pullRequest, er
 		}
 	}
 
+	var author string
+	if rawPullRequest.Author != nil {
+		author = rawPullRequest.Author.User.Name
+	}
+
+	var link string
+	if len(rawPullRequest.Links.Self) > 0 {
+		link = rawPullRequest.Links.Self[0].Href
+	}
+
 	pr = pullRequest{
 		Name:        rawPullRequest.Title,
 		Status:      c.getStatus(&rawPullRequest),
 		BuildStatus: c.getBuildStatus(rawPullRequest.FromRef.LatestCommit),
+		Author:      author,
+		Link:        link,
 		Approvers:   approvers,
 	}
 
@@ -97,32 +109,40 @@ func (c *bitbucketFetcher) getStatus(pr *bitbucket.PullRequest) prStatus {
 
 // try to extract the current build Status from a PR, based on the recent commit
 func (c *bitbucketFetcher) getBuildStatus(lastCommit string) buildStatus {
-	buildStatus := buildStatusUnknown
+	status := buildStatusUnknown
 	if lastCommit == "" {
-		return buildStatus
+		return status
 	}
 
 	rawBuilds, err := c.bitbucketClient.GetCommitBuildStatuses(lastCommit)
 	if err != nil {
-		return buildStatus
+		return status
 	}
 
 	builds, err := bitbucket.GetBuildStatusesResponse(rawBuilds)
 	if err != nil {
-		return buildStatus
+		return status
 	}
+
 	for _, build := range builds {
 		switch build.State {
-		case "SUCCESS":
-			return buildStatusSuccess
+		case "SUCCESS", "SUCCESSFUL":
+			if status == buildStatusUnknown {
+				status = buildStatusSuccess
+			}
+			break
 		case "INPROGRESS":
-			return buildStatusRunning
+			status = buildStatusRunning
+			break
 		case "FAILED":
-			return buildStatusFailed
+			if status != buildStatusRunning {
+				status = buildStatusFailed
+			}
+			break
 		}
 	}
 
-	return buildStatus
+	return status
 }
 
 func (c *bitbucketFetcher) GetTemplateFunction() template.FuncMap {

--- a/command/pullrequest/github.go
+++ b/command/pullrequest/github.go
@@ -80,9 +80,21 @@ func (c *githubFetcher) getPullRequest(match matcher.Result) (pullRequest, error
 		}
 	}
 
+	var author string
+	if rawPullRequest.User != nil && rawPullRequest.User.Login != nil {
+		author = *rawPullRequest.User.Login
+	}
+
+	var link string
+	if rawPullRequest.URL != nil {
+		link = *rawPullRequest.URL
+	}
+
 	pr = pullRequest{
 		Name:      rawPullRequest.GetTitle(),
 		Status:    c.getStatus(rawPullRequest, inReview),
+		Author:    author,
+		Link:      link,
 		Approvers: approvers,
 	}
 

--- a/command/pullrequest/github_test.go
+++ b/command/pullrequest/github_test.go
@@ -70,6 +70,8 @@ func TestGithub(t *testing.T) {
 
 		expected := pullRequest{
 			Name:      "Add weather command",
+			Author:    "pbojan",
+			Link:      "https://api.github.com/repos/innogames/slack-bot/pulls/1",
 			Status:    prStatusMerged,
 			Approvers: []string{},
 		}

--- a/command/pullrequest/gitlab.go
+++ b/command/pullrequest/gitlab.go
@@ -114,6 +114,8 @@ func (c *gitlabFetcher) convertToPullRequest(rawPullRequest *gitlab.MergeRequest
 		Name:        rawPullRequest.Title,
 		Approvers:   c.getApprovers(rawPullRequest, prNumber),
 		Status:      c.getStatus(rawPullRequest),
+		Author:      c.getAuthor(rawPullRequest),
+		Link:        rawPullRequest.WebURL,
 		BuildStatus: c.getPipelineStatus(rawPullRequest),
 	}
 }
@@ -135,4 +137,11 @@ func (c *gitlabFetcher) getPipelineStatus(pr *gitlab.MergeRequest) buildStatus {
 	default:
 		return buildStatusUnknown
 	}
+}
+
+func (c *gitlabFetcher) getAuthor(rawPullRequest *gitlab.MergeRequest) string {
+	if rawPullRequest.Author != nil {
+		return rawPullRequest.Author.Username
+	}
+	return ""
 }

--- a/command/pullrequest/pull_request.go
+++ b/command/pullrequest/pull_request.go
@@ -274,6 +274,7 @@ func (c command) getBuildStatusIcon(pr pullRequest) string {
 		return fmt.Sprintf(":%s:", c.cfg.Reactions.BuildSuccess)
 	case buildStatusFailed:
 		return fmt.Sprintf(":%s:", c.cfg.Reactions.BuildFailed)
+	case buildStatusUnknown:
 	}
 	return ""
 }

--- a/command/pullrequest/pull_request.go
+++ b/command/pullrequest/pull_request.go
@@ -3,6 +3,7 @@ package pullrequest
 import (
 	"fmt"
 	"net"
+	"strings"
 	"text/template"
 	"time"
 
@@ -293,13 +294,13 @@ func (c command) notifyBuildStatus(prw *pullRequestWatch) {
 	prw.LastBuildStatus = prw.PullRequest.BuildStatus
 
 	if c.cfg.Notifications.BuildStatusInProgress && prw.LastBuildStatus == buildStatusRunning {
-		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Started %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+		c.sendPrivateMessage(prw.PullRequest.Author, "PR '%s'\nBuild Status: Started %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
 	}
 	if c.cfg.Notifications.BuildStatusSuccess && prw.PullRequest.BuildStatus == buildStatusSuccess {
-		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Success %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+		c.sendPrivateMessage(prw.PullRequest.Author, "PR '%s'\nBuild Status: Success %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
 	}
 	if c.cfg.Notifications.BuildStatusFailed && prw.PullRequest.BuildStatus == buildStatusFailed {
-		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Failed %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+		c.sendPrivateMessage(prw.PullRequest.Author, "PR '%s'\nBuild Status: Failed %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
 	}
 }
 
@@ -325,7 +326,16 @@ func (c command) notifyPullRequestStatus(prw *pullRequestWatch) {
 
 	prw.DidNotifyMergeable = true
 
-	c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "Your PR '%s' is ready to merge!%s", prw.PullRequest.Name, getPRLinkMessage(prw))
+	c.sendPrivateMessage(prw.PullRequest.Author, "Your PR '%s' is ready to merge!%s", prw.PullRequest.Name, getPRLinkMessage(prw))
+}
+
+func (c command) sendPrivateMessage(username string, format string, parameter ...any) {
+	pmChannel := username
+	if !strings.HasPrefix(username, "@") {
+		pmChannel = fmt.Sprintf("@%s", username)
+	}
+	message := fmt.Sprintf(format, parameter...)
+	c.SendToUser(pmChannel, message)
 }
 
 func (c command) GetTemplateFunction() template.FuncMap {

--- a/command/pullrequest/pull_request.go
+++ b/command/pullrequest/pull_request.go
@@ -3,7 +3,6 @@ package pullrequest
 import (
 	"fmt"
 	"net"
-	"strings"
 	"text/template"
 	"time"
 
@@ -330,12 +329,8 @@ func (c command) notifyPullRequestStatus(prw *pullRequestWatch) {
 }
 
 func (c command) sendPrivateMessage(username string, format string, parameter ...any) {
-	pmChannel := username
-	if !strings.HasPrefix(username, "@") {
-		pmChannel = fmt.Sprintf("@%s", username)
-	}
 	message := fmt.Sprintf(format, parameter...)
-	c.SendToUser(pmChannel, message)
+	c.SendToUser(username, message)
 }
 
 func (c command) GetTemplateFunction() template.FuncMap {

--- a/command/pullrequest/pull_request.go
+++ b/command/pullrequest/pull_request.go
@@ -1,6 +1,7 @@
 package pullrequest
 
 import (
+	"fmt"
 	"net"
 	"text/template"
 	"time"
@@ -63,6 +64,12 @@ type pullRequest struct {
 	// status of a related CI build
 	BuildStatus buildStatus
 
+	// author of the PR
+	Author string
+
+	// link to the PR
+	Link string
+
 	// list of usernames which approved the PR
 	Approvers []string
 }
@@ -82,6 +89,13 @@ func (c command) execute(match matcher.Result, message msg.Message) {
 	go c.watch(match, message)
 }
 
+type pullRequestWatch struct {
+	DidNotifyMergeable bool
+	PullRequest        pullRequest
+	LastBuildStatus    buildStatus
+	PullRequestStatus  prStatus
+}
+
 func (c command) watch(match matcher.Result, message msg.Message) {
 	msgRef := slack.NewRefToMessage(message.Channel, message.Timestamp)
 	currentErrorCount := 0
@@ -92,11 +106,11 @@ func (c command) watch(match matcher.Result, message msg.Message) {
 	delay := util.GetIncreasingDelay(minCheckInterval, maxCheckInterval)
 	currentReactions := c.getOwnReactions(msgRef)
 
-	var pr pullRequest
+	var prw pullRequestWatch
 	var err error
 
 	for {
-		pr, err = c.fetcher.getPullRequest(match)
+		prw.PullRequest, err = c.fetcher.getPullRequest(match)
 
 		// something failed while loading the PR data...retry if it was temporary, else quit watching
 		if err != nil {
@@ -123,10 +137,14 @@ func (c command) watch(match matcher.Result, message msg.Message) {
 		}
 		currentErrorCount = 0
 
-		c.setPRReactions(pr, currentReactions, message)
+		c.setPRReactions(prw.PullRequest, currentReactions, message)
+
+		c.notifyBuildStatus(&prw)
+
+		c.notifyPullRequestStatus(&prw)
 
 		// stop watching!
-		if pr.Status == prStatusClosed || pr.Status == prStatusMerged {
+		if prw.PullRequest.Status == prStatusClosed || prw.PullRequest.Status == prStatusMerged {
 			return
 		}
 
@@ -239,6 +257,74 @@ func (c command) getApproveReactions(approvers []string) reactionMap {
 	}
 
 	return reactions
+}
+
+func getPRLinkMessage(prw *pullRequestWatch) string {
+	if len(prw.PullRequest.Link) > 0 {
+		return fmt.Sprintf("\nYou can check it here: %s", prw.PullRequest.Link)
+	}
+	return ""
+}
+
+func (c command) getBuildStatusIcon(pr pullRequest) string {
+	switch pr.BuildStatus {
+	case buildStatusRunning:
+		return fmt.Sprintf(":%s:", c.cfg.Reactions.BuildRunning)
+	case buildStatusSuccess:
+		return fmt.Sprintf(":%s:", c.cfg.Reactions.BuildSuccess)
+	case buildStatusFailed:
+		return fmt.Sprintf(":%s:", c.cfg.Reactions.BuildFailed)
+	}
+	return ""
+}
+
+func (c command) notifyBuildStatus(prw *pullRequestWatch) {
+	if len(prw.PullRequest.Author) == 0 {
+		// no author to notify
+		return
+	}
+
+	if prw.PullRequest.BuildStatus == prw.LastBuildStatus {
+		// build status didn't change
+		return
+	}
+
+	prw.LastBuildStatus = prw.PullRequest.BuildStatus
+
+	if c.cfg.Notifications.BuildStatusInProgress && prw.LastBuildStatus == buildStatusRunning {
+		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Started %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+	}
+	if c.cfg.Notifications.BuildStatusSuccess && prw.PullRequest.BuildStatus == buildStatusSuccess {
+		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Success %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+	}
+	if c.cfg.Notifications.BuildStatusFailed && prw.PullRequest.BuildStatus == buildStatusFailed {
+		c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "PR '%s'\nBuild Status: Failed %s%s", prw.PullRequest.Name, c.getBuildStatusIcon(prw.PullRequest), getPRLinkMessage(prw))
+	}
+}
+
+func (c command) notifyPullRequestStatus(prw *pullRequestWatch) {
+	if prw.DidNotifyMergeable {
+		return
+	}
+
+	if len(prw.PullRequest.Author) == 0 {
+		// no author to notify
+		return
+	}
+
+	if len(prw.PullRequest.Approvers) == 0 {
+		// prw isn't approved
+		return
+	}
+
+	if prw.PullRequest.BuildStatus != buildStatusSuccess {
+		// has still running or failed builds
+		return
+	}
+
+	prw.DidNotifyMergeable = true
+
+	c.SendToUser(fmt.Sprintf("@%s", prw.PullRequest.Author), "Your PR '%s' is ready to merge!%s", prw.PullRequest.Name, getPRLinkMessage(prw))
 }
 
 func (c command) GetTemplateFunction() template.FuncMap {

--- a/mocks/SlackClient.go
+++ b/mocks/SlackClient.go
@@ -3,7 +3,6 @@
 package mocks
 
 import (
-	"fmt"
 	msg "github.com/innogames/slack-bot/v2/bot/msg"
 	mock "github.com/stretchr/testify/mock"
 
@@ -147,6 +146,6 @@ func (_m *SlackClient) SendMessage(ref msg.Ref, text string, options ...slack.Ms
 }
 
 // SendToUser provides a mock function with given fields: user, text
-func (_m *SlackClient) SendToUser(user string, format string, parameter ...any) {
-	_m.Called(user, fmt.Sprintf(format, parameter...))
+func (_m *SlackClient) SendToUser(user string, message string) {
+	_m.Called(user, message)
 }

--- a/mocks/SlackClient.go
+++ b/mocks/SlackClient.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"fmt"
 	msg "github.com/innogames/slack-bot/v2/bot/msg"
 	mock "github.com/stretchr/testify/mock"
 
@@ -146,6 +147,6 @@ func (_m *SlackClient) SendMessage(ref msg.Ref, text string, options ...slack.Ms
 }
 
 // SendToUser provides a mock function with given fields: user, text
-func (_m *SlackClient) SendToUser(user string, text string) {
-	_m.Called(user, text)
+func (_m *SlackClient) SendToUser(user string, format string, parameter ...any) {
+	_m.Called(user, fmt.Sprintf(format, parameter...))
 }


### PR DESCRIPTION
in some cases it's helpful to get notifications via PM to know the progress of a PR and if it needs more care.
this PR will provide a configurable way to send PMs on PR & build status changes dependent on the configuration.

it will also change the way how the build progress is reported.
to have a successful build all builds needs to be successful not only the first one.