### PR TITLE
openai: add a config to evaluate all unknown commands as GPT command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-coverage: dep
 	@mkdir -p build
 	go test ./... -coverpkg=./... -cover -coverprofile=./build/cover.out -covermode=atomic
 	go tool cover -html=./build/cover.out -o ./build/cover.html
-	@echo see ./build/cover.html
+	@go tool cover -func ./build/cover.out | grep total | awk '{print "Total Coverage: " $$3 " see ./build/cover.html"}'
 
 # build mocks for testable interfaces into ./mocks/ directory
 mocks: dep

--- a/command/openai/config.go
+++ b/command/openai/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// number of thread messages stored which are used as a context for further requests
 	HistorySize int `mapstructure:"history_size"`
 
+	// is no other command matched, evaluate the message with openai
+	UseAsFallback bool `mapstructure:"use_as_fallback"`
+
 	// maximum update frequency of slack messages when "stream" is active
 	UpdateInterval time.Duration `mapstructure:"update_interval"`
 }


### PR DESCRIPTION
useful if a bot should be only be used for openai commands -> all (unknown) commands will start a openai conversation. 
Known commands as "help" will be still handled as usual bot request

```yaml
openai:
  use_as_fallback: true  
```
