### PR TITLE
Align token count for gpt-3.5-turbo with official docs

### DIFF
--- a/command/openai/tokens.go
+++ b/command/openai/tokens.go
@@ -10,7 +10,7 @@ var maxTokens = map[string]int{
 	"gpt-4":                8192,
 	"gpt-4-32k":            32768,
 	"gpt-3.5-turbo-16k":    16385,
-	"gpt-3.5-turbo":        4097,
+	"gpt-3.5-turbo":        4096,
 	"gpt-4-1106-preview":   128000,
 	"gpt-4-vision-preview": 128000,
 	"dummy-test":           100, // just for testing

--- a/command/openai/tokens_test.go
+++ b/command/openai/tokens_test.go
@@ -16,7 +16,7 @@ func TestModels(t *testing.T) {
 		{"gpt-4", 8192},
 		{"gpt-4-0613", 8192},
 		{"gpt-4-32k-0613", 32768},
-		{"gpt-3.5-turbo", 4097},
+		{"gpt-3.5-turbo", 4096},
 		{"gpt-3.5-turbo-16k-0613", 16385},
 	}
 


### PR DESCRIPTION
Hi,

at the time of writing `gpt-3.5-turbo` allows for 4096 - not 4097 - tokens.

<img width="819" alt="image" src="https://github.com/innogames/slack-bot/assets/6304496/ed084274-5f47-4327-a38a-1f19b6687872">

Cheers,
Christoph