### PR TITLE
cron: use channel name from config without channel lookup

### DIFF
--- a/command/cron/command.go
+++ b/command/cron/command.go
@@ -67,7 +67,7 @@ func (c *command) getCallback(cron config.Cron) func() {
 			for _, line := range strings.Split(text, "\n") {
 				newMessage := msg.Message{}
 				newMessage.User = "cron"
-				newMessage.Channel, _ = client.GetChannelIDAndName(cron.Channel)
+				newMessage.Channel = cron.Channel
 				newMessage.Text = line
 				client.HandleMessage(newMessage)
 			}

--- a/command/cron/cron_test.go
+++ b/command/cron/cron_test.go
@@ -77,6 +77,7 @@ func TestCron(t *testing.T) {
 
 		baseMessage := msg.Message{}
 		baseMessage.User = "cron"
+		baseMessage.Channel = "#dev"
 
 		mocks.AssertQueuedMessage(t, baseMessage.WithText("reply foo"))
 		mocks.AssertQueuedMessage(t, baseMessage.WithText("reply bar1"))


### PR DESCRIPTION
This PR uses the target Slack channel directly from the config without channel lookup.

A side effect of this is that scheduled commands can now post to private channels, in which the bot is invited.