### PR TITLE
cron: handle commands in deterministic order

### DIFF
--- a/command/cron/command.go
+++ b/command/cron/command.go
@@ -69,7 +69,7 @@ func (c *command) getCallback(cron config.Cron) func() {
 				newMessage.User = "cron"
 				newMessage.Channel = cron.Channel
 				newMessage.Text = line
-				client.HandleMessage(newMessage)
+				client.HandleMessageWithDoneHandler(newMessage).Wait()
 			}
 		}
 	}

--- a/command/cron/cron_test.go
+++ b/command/cron/cron_test.go
@@ -71,6 +71,8 @@ func TestCron(t *testing.T) {
 	t.Run("Execute", func(t *testing.T) {
 		jobs := command.cron.Entries()
 		assert.Len(t, jobs, 2)
+		getMessages := mocks.WaitForQueuedMessages(t, 4)
+
 		for _, job := range jobs {
 			job.Job.Run()
 		}
@@ -79,9 +81,10 @@ func TestCron(t *testing.T) {
 		baseMessage.User = "cron"
 		baseMessage.Channel = "#dev"
 
-		mocks.AssertQueuedMessage(t, baseMessage.WithText("reply foo"))
-		mocks.AssertQueuedMessage(t, baseMessage.WithText("reply bar1"))
-		mocks.AssertQueuedMessage(t, baseMessage.WithText("reply bar2"))
+		actualMessages := getMessages()
+		assert.Equal(t, baseMessage.WithText("reply foo"), actualMessages[0])
+		assert.Equal(t, baseMessage.WithText("reply bar1"), actualMessages[1])
+		assert.Equal(t, baseMessage.WithText("reply bar2"), actualMessages[2])
 	})
 
 	t.Run("Test help", func(t *testing.T) {


### PR DESCRIPTION
This PR ensures that commands are handled sequentially, if used in templates

Example
```
reply First message
reply Second message
reply Third message
```
Previously the commands were handled in goroutines and therefore the order of Slack messages was non-deterministic, now they are handled one at time.