### PR TITLE
pullrequest: add Jira-severity emoji reactions to watched PRs

### DIFF
--- a/bot/config/default.go
+++ b/bot/config/default.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/innogames/slack-bot/v2/bot/util"
+)
 
 // DefaultConfig with some common values
 var DefaultConfig = Config{
@@ -43,6 +47,13 @@ var DefaultConfig = Config{
 			BuildFailed:  "fire",
 			BuildRunning: "arrows_counterclockwise",
 			Error:        "x",
+		},
+		JiraPriorityReactions: map[string]util.Reaction{
+			"Blocker":  "jira_blocker",
+			"Critical": "jira_critical",
+			"Major":    "jira_major",
+			"Medium":   "jira_medium",
+			"Minor":    "jira_minor",
 		},
 	},
 	BranchLookup: VCS{

--- a/bot/config/pull_request.go
+++ b/bot/config/pull_request.go
@@ -12,6 +12,11 @@ type PullRequest struct {
 
 	// able to set a custom "approved" reactions to see directly who or which component/department approved a pullrequest
 	CustomApproveReaction map[string]util.Reaction `mapstructure:"custom_approve_reaction"`
+
+	// maps a Jira priority name (Blocker, Critical, …) to a reaction which is added to watched
+	// pull requests, based on the Jira ticket referenced in the branch name or PR title.
+	// Requires a configured Jira connection (see "jira" section).
+	JiraPriorityReactions map[string]util.Reaction `mapstructure:"jira_priority_reactions"`
 }
 
 // Notifications can be defined in the config.yaml to enable notifications for pull request builds.

--- a/command/jira/client.go
+++ b/command/jira/client.go
@@ -8,8 +8,8 @@ import (
 	"github.com/innogames/slack-bot/v2/client"
 )
 
-// getClient creates a jira client based on github.com/andygrunwald/go-jira and passes authentication credentials
-func getClient(cfg *config.Jira) (*jira.Client, error) {
+// GetClient creates a jira client based on github.com/andygrunwald/go-jira and passes authentication credentials
+func GetClient(cfg *config.Jira) (*jira.Client, error) {
 	var httpClient *http.Client
 
 	switch {

--- a/command/jira/client_test.go
+++ b/command/jira/client_test.go
@@ -13,7 +13,7 @@ func TestJiraClient(t *testing.T) {
 		cfg := &config.Jira{
 			Host: "https://jira.example.com",
 		}
-		client, err := getClient(cfg)
+		client, err := GetClient(cfg)
 
 		require.NoError(t, err)
 		assert.Equal(t, "jira.example.com", client.GetBaseURL().Host)
@@ -25,7 +25,7 @@ func TestJiraClient(t *testing.T) {
 			Username: "foo",
 			Password: "bar",
 		}
-		client, err := getClient(cfg)
+		client, err := GetClient(cfg)
 
 		require.NoError(t, err)
 		assert.False(t, client.Authentication.Authenticated())
@@ -37,7 +37,7 @@ func TestJiraClient(t *testing.T) {
 			Username:    "foo",
 			AccessToken: "iamsecret",
 		}
-		client, err := getClient(cfg)
+		client, err := GetClient(cfg)
 
 		require.NoError(t, err)
 		assert.False(t, client.Authentication.Authenticated())

--- a/command/jira/commands.go
+++ b/command/jira/commands.go
@@ -15,7 +15,7 @@ func GetCommands(cfg *config.Jira, slackClient client.SlackClient) bot.Commands 
 		return commands
 	}
 
-	jira, err := getClient(cfg)
+	jira, err := GetClient(cfg)
 	if err != nil {
 		log.Error(err)
 		return commands

--- a/command/jira/comment_test.go
+++ b/command/jira/comment_test.go
@@ -31,7 +31,7 @@ func TestCommentJira(t *testing.T) {
 		Host:    server.URL,
 		Project: "TEST",
 	}
-	jiraClient, err := getClient(cfg)
+	jiraClient, err := GetClient(cfg)
 	require.NoError(t, err)
 
 	command := bot.Commands{}

--- a/command/jira/search_test.go
+++ b/command/jira/search_test.go
@@ -21,7 +21,7 @@ func TestJiraSearch(t *testing.T) {
 		Host:    "https://issues.apache.org/jira/",
 		Project: "ZOOKEEPER",
 	}
-	jiraClient, err := getClient(cfg)
+	jiraClient, err := GetClient(cfg)
 	require.NoError(t, err)
 
 	command := bot.Commands{}

--- a/command/jira/watch_test.go
+++ b/command/jira/watch_test.go
@@ -18,7 +18,7 @@ func TestWatchJira(t *testing.T) {
 	cfg := &config.Jira{
 		Host: "https://issues.apache.org/jira/",
 	}
-	jiraClient, err := getClient(cfg)
+	jiraClient, err := GetClient(cfg)
 	require.NoError(t, err)
 
 	command := bot.Commands{}

--- a/command/pullrequest/bitbucket.go
+++ b/command/pullrequest/bitbucket.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	gojira "github.com/andygrunwald/go-jira"
 	bitbucket "github.com/gfleury/go-bitbucket-v1"
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
@@ -23,7 +24,7 @@ var closedPr = pullRequest{
 	Status: prStatusClosed,
 }
 
-func newBitbucketCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
+func newBitbucketCommand(base bot.BaseCommand, cfg *config.Config, jiraClient *gojira.Client) bot.Command {
 	if !cfg.Bitbucket.IsEnabled() {
 		return nil
 	}
@@ -39,6 +40,7 @@ func newBitbucketCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
 		cfg.PullRequest,
 		&bitbucketFetcher{bitbucketClient},
 		"(?s).*" + regexp.QuoteMeta(cfg.Bitbucket.Host) + "/projects/(?P<project>.+)/repos/(?P<repo>.+)/pull-requests/(?P<number>\\d+).*",
+		jiraClient,
 	}
 }
 
@@ -99,6 +101,7 @@ func (c *bitbucketFetcher) getPullRequest(match matcher.Result, config *config.P
 		BuildStatus:                   c.getBuildStatus(rawPullRequest.FromRef.LatestCommit),
 		Author:                        author,
 		Link:                          link,
+		Branch:                        rawPullRequest.FromRef.DisplayID,
 		Approvers:                     approvers,
 		LatestReviewCommentsTimestamp: latestCommentTimestamp,
 	}

--- a/command/pullrequest/bitbucket_test.go
+++ b/command/pullrequest/bitbucket_test.go
@@ -25,7 +25,7 @@ func TestBitbucketNotActive(t *testing.T) {
 	cfg := &config.DefaultConfig
 
 	command := bot.Commands{}
-	cmd := newBitbucketCommand(base, cfg)
+	cmd := newBitbucketCommand(base, cfg, nil)
 	command.AddCommand(cmd)
 
 	t.Run("invalid command", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestBitbucketFakeServer(t *testing.T) {
 	}
 
 	command := bot.Commands{}
-	cmd := newBitbucketCommand(base, &cfg)
+	cmd := newBitbucketCommand(base, &cfg, nil)
 	command.AddCommand(cmd)
 
 	t.Run("Merged PR", func(t *testing.T) {

--- a/command/pullrequest/commands.go
+++ b/command/pullrequest/commands.go
@@ -1,8 +1,11 @@
 package pullrequest
 
 import (
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
+	"github.com/innogames/slack-bot/v2/command/jira"
+	log "github.com/sirupsen/logrus"
 )
 
 var category = bot.Category{
@@ -15,10 +18,21 @@ var category = bot.Category{
 func GetCommands(base bot.BaseCommand, cfg *config.Config) bot.Commands {
 	commands := bot.Commands{}
 
+	// optional Jira client to resolve the priority/severity of the ticket referenced by a PR
+	var jiraClient *gojira.Client
+	if cfg.Jira.IsEnabled() {
+		if client, err := jira.GetClient(&cfg.Jira); err == nil {
+			jiraClient = client
+		} else {
+			// non-fatal: PR watching still works, just without severity reactions
+			log.Warnf("error while initializing Jira client for PR severity: %s", err)
+		}
+	}
+
 	commands.AddCommand(
-		newGitlabCommand(base, cfg),
-		newGithubCommand(base, cfg),
-		newBitbucketCommand(base, cfg),
+		newGitlabCommand(base, cfg, jiraClient),
+		newGithubCommand(base, cfg, jiraClient),
+		newBitbucketCommand(base, cfg, jiraClient),
 	)
 
 	return commands

--- a/command/pullrequest/github.go
+++ b/command/pullrequest/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"text/template"
 
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/google/go-github/github"
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
@@ -17,7 +18,7 @@ type githubFetcher struct {
 	client *github.Client
 }
 
-func newGithubCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
+func newGithubCommand(base bot.BaseCommand, cfg *config.Config, jiraClient *gojira.Client) bot.Command {
 	var githubClient *github.Client
 	if cfg.Github.AccessToken == "" {
 		githubClient = github.NewClient(client.GetHTTPClient())
@@ -38,6 +39,7 @@ func newGithubCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
 		cfg.PullRequest,
 		&githubFetcher{githubClient},
 		"(?s).*https://github.com/(?P<project>.+)/(?P<repo>.+)/pull/(?P<number>\\d+).*",
+		jiraClient,
 	}
 }
 
@@ -94,6 +96,7 @@ func (c *githubFetcher) getPullRequest(match matcher.Result, _ *config.PullReque
 		Status:    c.getStatus(rawPullRequest, inReview),
 		Author:    author,
 		Link:      link,
+		Branch:    rawPullRequest.GetHead().GetRef(),
 		Approvers: approvers,
 	}
 

--- a/command/pullrequest/github_test.go
+++ b/command/pullrequest/github_test.go
@@ -26,7 +26,7 @@ func TestGithub(t *testing.T) {
 	cfg.Github.AccessToken = os.Getenv("BOT_GITHUB_ACCESS_TOKEN")
 
 	commands := bot.Commands{}
-	cmd := newGithubCommand(base, cfg).(command)
+	cmd := newGithubCommand(base, cfg, nil).(command)
 	githubFetcher := cmd.fetcher.(*githubFetcher)
 	commands.AddCommand(cmd)
 
@@ -74,6 +74,7 @@ func TestGithub(t *testing.T) {
 			Name:      "Add weather command",
 			Author:    "pbojan",
 			Link:      "https://api.github.com/repos/innogames/slack-bot/pulls/1",
+			Branch:    "add-weather-command",
 			Status:    prStatusMerged,
 			Approvers: []string{},
 		}

--- a/command/pullrequest/gitlab.go
+++ b/command/pullrequest/gitlab.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"text/template"
 
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
 	"github.com/innogames/slack-bot/v2/bot/matcher"
@@ -17,7 +18,7 @@ type gitlabFetcher struct {
 	client *gitlab.Client
 }
 
-func newGitlabCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
+func newGitlabCommand(base bot.BaseCommand, cfg *config.Config, jiraClient *gojira.Client) bot.Command {
 	if cfg.Gitlab.AccessToken == "" && cfg.Gitlab.Host == "" {
 		return nil
 	}
@@ -33,6 +34,7 @@ func newGitlabCommand(base bot.BaseCommand, cfg *config.Config) bot.Command {
 		cfg.PullRequest,
 		&gitlabFetcher{gitlabClient},
 		"(?s).*" + regexp.QuoteMeta(cfg.Gitlab.Host) + "/(?P<repo>.+/.+)/merge_requests/(?P<number>\\d+).*",
+		jiraClient,
 	}
 }
 
@@ -125,6 +127,7 @@ func (c *gitlabFetcher) convertToPullRequest(rawPullRequest *gitlab.MergeRequest
 		Status:      c.getStatus(rawPullRequest),
 		Author:      c.getAuthor(rawPullRequest),
 		Link:        rawPullRequest.WebURL,
+		Branch:      rawPullRequest.SourceBranch,
 		BuildStatus: c.getPipelineStatus(rawPullRequest),
 	}
 }

--- a/command/pullrequest/gitlab_test.go
+++ b/command/pullrequest/gitlab_test.go
@@ -27,7 +27,7 @@ func TestGitlab(t *testing.T) {
 	cfg.Gitlab.AccessToken = "0815"
 
 	commands := bot.Commands{}
-	cmd := newGitlabCommand(base, cfg).(command)
+	cmd := newGitlabCommand(base, cfg, nil).(command)
 	gitlabFetcher := cmd.fetcher.(*gitlabFetcher)
 
 	commands.AddCommand(cmd)

--- a/command/pullrequest/pull_request.go
+++ b/command/pullrequest/pull_request.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"slices"
 	"text/template"
 	"time"
 
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/innogames/slack-bot/v2/bot"
 	"github.com/innogames/slack-bot/v2/bot/config"
 	"github.com/innogames/slack-bot/v2/bot/matcher"
@@ -18,6 +20,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 )
+
+// jiraTicketRegexp matches a Jira ticket key like "TEST-123" inside a branch name or PR title
+var jiraTicketRegexp = regexp.MustCompile(`[A-Z][A-Z0-9]+-\d+`)
 
 const (
 	minCheckInterval = time.Second * 30
@@ -56,6 +61,10 @@ type command struct {
 	cfg     config.PullRequest
 	fetcher fetcher
 	regexp  string
+
+	// optional Jira client, used to resolve the priority/severity of the referenced ticket.
+	// nil when Jira is not configured.
+	jira *gojira.Client
 }
 
 type pullRequest struct {
@@ -71,6 +80,9 @@ type pullRequest struct {
 
 	// link to the PR
 	Link string
+
+	// source branch of the PR, e.g. "bugfix/TEST-123-fix-xyz" (used to resolve the Jira ticket)
+	Branch string
 
 	// list of usernames which approved the PR
 	Approvers []string
@@ -100,6 +112,10 @@ type pullRequestWatch struct {
 	LastBuildStatus                   buildStatus
 	PullRequestStatus                 prStatus
 	SavedLatestReviewCommentTimestamp int64
+
+	// reaction representing the Jira priority/severity of the PR; resolved once per watcher
+	SeverityReaction util.Reaction
+	severityResolved bool
 }
 
 func (c command) watch(match matcher.Result, message msg.Message) {
@@ -145,7 +161,17 @@ func (c command) watch(match matcher.Result, message msg.Message) {
 		}
 		currentErrorCount = 0
 
+		// resolve the Jira priority once: it's stable for the PR's lifetime
+		if !prw.severityResolved {
+			prw.SeverityReaction = c.getSeverityReaction(prw.PullRequest)
+			prw.severityResolved = true
+		}
+
 		c.setPRReactions(prw.PullRequest, currentReactions, message)
+
+		if prw.SeverityReaction != "" {
+			c.addReaction(currentReactions, prw.SeverityReaction, message)
+		}
 
 		c.notifyBuildStatus(&prw)
 
@@ -216,6 +242,48 @@ func (c command) processBuildStatus(pr pullRequest, currentReactions reactionMap
 	} else {
 		c.removeReaction(currentReactions, c.cfg.Reactions.BuildRunning, message)
 	}
+}
+
+// extractTicketKey returns the Jira ticket key referenced by the PR, preferring the branch
+// name (e.g. "bugfix/TEST-123-fix") over the PR title. Returns "" if none is found.
+func extractTicketKey(pr pullRequest) string {
+	if key := jiraTicketRegexp.FindString(pr.Branch); key != "" {
+		return key
+	}
+
+	return jiraTicketRegexp.FindString(pr.Name)
+}
+
+// getSeverityReaction resolves the configured reaction for the Jira priority of the ticket
+// referenced by the PR. Returns "" when Jira is not configured, no ticket is referenced, the
+// lookup fails, or the priority has no mapped reaction.
+func (c command) getSeverityReaction(pr pullRequest) util.Reaction {
+	if c.jira == nil || len(c.cfg.JiraPriorityReactions) == 0 {
+		return ""
+	}
+
+	ticketKey := extractTicketKey(pr)
+	if ticketKey == "" {
+		return ""
+	}
+
+	issue, _, err := c.jira.Issue.Get(ticketKey, &gojira.GetQueryOptions{Fields: "priority"})
+	if err != nil {
+		log.Warnf("error while loading Jira ticket %s for PR severity: %s", ticketKey, err)
+		return ""
+	}
+
+	if issue.Fields == nil || issue.Fields.Priority == nil {
+		return ""
+	}
+
+	if reaction, ok := c.cfg.JiraPriorityReactions[issue.Fields.Priority.Name]; ok {
+		return reaction
+	}
+
+	log.Infof("no severity reaction mapped for Jira priority: %s", issue.Fields.Priority.Name)
+
+	return ""
 }
 
 // get the current reactions in the given message which got created by this bot user

--- a/command/pullrequest/pull_request_test.go
+++ b/command/pullrequest/pull_request_test.go
@@ -169,6 +169,7 @@ func initTest(slackClient client.SlackClient) (bot.Commands, *testFetcher) {
 		cfg.PullRequest,
 		fetcher,
 		".*/projects/(?P<project>.+)/repos/(?P<repo>.+)/pull-requests/(?P<number>\\d+).*",
+		nil,
 	}
 	commands.AddCommand(cmd)
 

--- a/command/pullrequest/severity_test.go
+++ b/command/pullrequest/severity_test.go
@@ -1,0 +1,105 @@
+package pullrequest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gojira "github.com/andygrunwald/go-jira"
+	"github.com/innogames/slack-bot/v2/bot/config"
+	"github.com/innogames/slack-bot/v2/bot/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTicketKey(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pr       pullRequest
+		expected string
+	}{
+		{
+			name:     "key in branch is preferred",
+			pr:       pullRequest{Branch: "bugfix/TEST-123-fix-xyz", Name: "PROJ-999: unrelated title"},
+			expected: "TEST-123",
+		},
+		{
+			name:     "key at the start of the branch",
+			pr:       pullRequest{Branch: "TEST-123-bugfix"},
+			expected: "TEST-123",
+		},
+		{
+			name:     "fallback to title when branch has no key",
+			pr:       pullRequest{Branch: "feature/some-cleanup", Name: "TEST-456: add feature"},
+			expected: "TEST-456",
+		},
+		{
+			name:     "no key at all",
+			pr:       pullRequest{Branch: "feature/cleanup", Name: "just a title"},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractTicketKey(tc.pr))
+		})
+	}
+}
+
+func TestGetSeverityReaction(t *testing.T) {
+	priorityReactions := map[string]util.Reaction{
+		"Blocker": "jira_blocker",
+		"Major":   "jira_major",
+	}
+
+	t.Run("no jira client returns empty", func(t *testing.T) {
+		cmd := command{cfg: config.PullRequest{JiraPriorityReactions: priorityReactions}}
+		assert.Empty(t, cmd.getSeverityReaction(pullRequest{Branch: "TEST-1-fix"}))
+	})
+
+	// mock Jira server returning a fixed priority for any issue request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/rest/api/2/issue/TEST-123")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"TEST-123","fields":{"priority":{"name":"Blocker"}}}`))
+	}))
+	defer server.Close()
+
+	jiraClient, err := gojira.NewClient(http.DefaultClient, server.URL)
+	require.NoError(t, err)
+
+	cmd := command{
+		cfg:  config.PullRequest{JiraPriorityReactions: priorityReactions},
+		jira: jiraClient,
+	}
+
+	t.Run("maps priority to reaction", func(t *testing.T) {
+		reaction := cmd.getSeverityReaction(pullRequest{Branch: "bugfix/TEST-123-fix"})
+		assert.Equal(t, util.Reaction("jira_blocker"), reaction)
+	})
+
+	t.Run("no ticket key returns empty", func(t *testing.T) {
+		assert.Empty(t, cmd.getSeverityReaction(pullRequest{Branch: "feature/cleanup", Name: "no key"}))
+	})
+}
+
+func TestGetSeverityReactionUnmappedPriority(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"TEST-123","fields":{"priority":{"name":"Trivial"}}}`))
+	}))
+	defer server.Close()
+
+	jiraClient, err := gojira.NewClient(http.DefaultClient, server.URL)
+	require.NoError(t, err)
+
+	cmd := command{
+		cfg: config.PullRequest{JiraPriorityReactions: map[string]util.Reaction{
+			"Blocker": "jira_blocker",
+		}},
+		jira: jiraClient,
+	}
+
+	assert.Empty(t, cmd.getSeverityReaction(pullRequest{Branch: "TEST-123-fix"}))
+}

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,22 @@ pullrequest:
 
 ![Screenshot](./docs/pull-request.png)
 
+**Jira severity reactions:**
+If a [Jira connection](#jira) is configured, the bot can add a reaction based on the priority/severity of the Jira ticket referenced by the pull request. The ticket key is extracted from the **branch name** first (e.g. `bugfix/TEST-123-fix-xyz`) and falls back to the **PR title** (e.g. `TEST-123: fix login`). The mapping from Jira priority to reaction is configurable (defaults to the `jira_*` priority icons):
+<details>
+    <summary>Expand example!</summary>
+
+```yaml
+pullrequest:
+  jira_priority_reactions:
+    Blocker: "jira_blocker"
+    Critical: "jira_critical"
+    Major: "jira_major"
+    Medium: "jira_medium"
+    Minor: "jira_minor"
+```
+</details>
+
 **Extra Features:**
 For Bitbucket, the bot is able to extract the current build status (e.g., from Jenkins/Bamboo etc.) and show failed and running builds (fire reaction) as a reaction (circle arrow reaction). When the build is stable, the build reactions disappear.
 ![Screenshot](./docs/pull-request-build-status.png)


### PR DESCRIPTION
Resolve the Jira ticket referenced by a pull request (branch name preferred, PR title as fallback) and add a reaction reflecting the ticket's priority, e.g. Blocker -> :jira_blocker:. This makes urgent PRs distinguishable at a glance.

The priority-to-reaction mapping is configurable via pullrequest.jira_priority_reactions and the feature is opt-in: when Jira is not configured the lookup is skipped entirely, leaving existing PR-watching behavior unchanged.

Closes #313