### PR TITLE
bot: strip leading :robot_face: emoji from incoming messages

### DIFF
--- a/bot/bot_handle.go
+++ b/bot/bot_handle.go
@@ -69,6 +69,14 @@ func (b *Bot) cleanMessage(text string, fromUserContext bool) string {
 	text = strings.Trim(text, "*")
 	text = strings.TrimSpace(text)
 
+	// strip a leading :robot_face: emoji: messages coming from Claude/MCP are prefixed with it,
+	// which would otherwise prevent commands from matching the message
+	if trimmed, ok := strings.CutPrefix(text, ":robot_face:"); ok {
+		text = strings.TrimSpace(trimmed)
+	} else if trimmed, ok := strings.CutPrefix(text, "🤖"); ok {
+		text = strings.TrimSpace(trimmed)
+	}
+
 	// remove links from incoming messages. for internal ones they might be wanted, as they contain valid links with texts
 	if fromUserContext {
 		text = linkRegexp.ReplaceAllString(text, "$1")

--- a/bot/bot_handle_test.go
+++ b/bot/bot_handle_test.go
@@ -98,6 +98,14 @@ func TestIsBotMessage(t *testing.T) {
 		assert.Equal(t, "send message general hello", bot.cleanMessage("send message <#C123|general> hello", true))
 		assert.Equal(t, "notify user <@U123> active", bot.cleanMessage("notify user <@U123> active", true))
 		assert.Equal(t, "<https://test.com> <#C123|general>", bot.cleanMessage("<https://test.com> <#C123|general>", false))
+
+		// strip leading :robot_face: emoji prefixed by Claude/MCP messages
+		assert.Equal(t, "list jenkins nodes", bot.cleanMessage(":robot_face: list jenkins nodes", true))
+		assert.Equal(t, "list jenkins nodes", bot.cleanMessage("🤖 list jenkins nodes", true))
+		assert.Equal(t, "list jenkins nodes", bot.cleanMessage("<@BOT> :robot_face: list jenkins nodes", true))
+		assert.Equal(t, "list jenkins nodes", bot.cleanMessage("*:robot_face: list jenkins nodes*", true))
+		// only a leading emoji is stripped, not one in the middle of the message
+		assert.Equal(t, "reply :robot_face: is cute", bot.cleanMessage("reply :robot_face: is cute", true))
 	})
 }
 


### PR DESCRIPTION
Messages coming from Claude/MCP are prefixed with a :robot_face: emoji, which prevented most commands from matching the message. Strip a leading :robot_face: (shortcode or unicode) in cleanMessage so command handling works as expected.