### PR TITLE
bot: keep full URL when Slack truncates a link label

### DIFF
--- a/bot/bot_handle.go
+++ b/bot/bot_handle.go
@@ -18,7 +18,9 @@ import (
 )
 
 var (
-	linkRegexp     = regexp.MustCompile(`<\S+?\|(.*?)>`)
+	// linkRegexp matches a Slack link with a display label: <url|label>.
+	// Group 1 is the url, group 2 is the label.
+	linkRegexp     = regexp.MustCompile(`<(\S+?)\|(.*?)>`)
 	bareLinkRegexp = regexp.MustCompile(`<(https?://\S+?)>`)
 
 	// clean copy&paste crap from Mac etc
@@ -79,11 +81,29 @@ func (b *Bot) cleanMessage(text string, fromUserContext bool) string {
 
 	// remove links from incoming messages. for internal ones they might be wanted, as they contain valid links with texts
 	if fromUserContext {
-		text = linkRegexp.ReplaceAllString(text, "$1")
+		text = linkRegexp.ReplaceAllStringFunc(text, replaceSlackLink)
 		text = bareLinkRegexp.ReplaceAllString(text, "$1")
 	}
 
 	return text
+}
+
+// replaceSlackLink resolves a Slack link of the form <url|label> to plain text.
+// Normally the human-readable label is kept. But Slack truncates long labels with a
+// horizontal ellipsis ("…"), which would discard the part of the URL that commands
+// (e.g. the pull request watcher) need to match. In that case the full url is kept instead.
+func replaceSlackLink(link string) string {
+	groups := linkRegexp.FindStringSubmatch(link)
+	if groups == nil {
+		return link
+	}
+
+	url, label := groups[1], groups[2]
+	if strings.Contains(label, "…") {
+		return url
+	}
+
+	return label
 }
 
 // ProcessMessage process the incoming message and respond appropriately

--- a/bot/bot_handle_test.go
+++ b/bot/bot_handle_test.go
@@ -99,6 +99,15 @@ func TestIsBotMessage(t *testing.T) {
 		assert.Equal(t, "notify user <@U123> active", bot.cleanMessage("notify user <@U123> active", true))
 		assert.Equal(t, "<https://test.com> <#C123|general>", bot.cleanMessage("<https://test.com> <#C123|general>", false))
 
+		// when Slack truncates the display label of a link (indicated by the … ellipsis),
+		// keep the full URL instead of the useless truncated label so commands still match.
+		assert.Equal(t,
+			"https://test.com/foo/bar/baz/123/overview",
+			bot.cleanMessage("<https://test.com/foo/bar/baz/123/overview|test.com/foo/…/overview>", true),
+		)
+		// a normal, non-truncated label is still preferred over the URL
+		assert.Equal(t, "TEST", bot.cleanMessage("<https://test.com|TEST>", true))
+
 		// strip leading :robot_face: emoji prefixed by Claude/MCP messages
 		assert.Equal(t, "list jenkins nodes", bot.cleanMessage(":robot_face: list jenkins nodes", true))
 		assert.Equal(t, "list jenkins nodes", bot.cleanMessage("🤖 list jenkins nodes", true))


### PR DESCRIPTION
Incoming Slack links of the form <url|label> were cleaned to their display label. When Slack truncates a long label (indicated by a "…" ellipsis), the truncated label replaced the URL, so the pull request watcher's regex could no longer find the /pull-requests/<number> path and responded with "Command ... not found".

Keep the full URL instead of the label whenever the label is truncated, while still preferring the human-readable label in the normal case.